### PR TITLE
Test suite non-ascii fix

### DIFF
--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -373,6 +373,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
 

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -379,6 +379,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -373,6 +373,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -63,6 +63,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         // outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -69,6 +69,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -63,6 +63,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         // outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -364,6 +364,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
 

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -370,6 +370,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -364,6 +364,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -65,6 +65,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
@@ -71,6 +71,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
@@ -65,6 +65,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pkd3.cpp
+++ b/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pkd3.cpp
@@ -363,6 +363,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
 

--- a/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pln1.cpp
+++ b/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pln1.cpp
@@ -370,6 +370,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)

--- a/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pln3.cpp
+++ b/utilities/rpp-performancetests/OCL_NEW/BatchPD_ocl_pln3.cpp
@@ -364,6 +364,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -375,6 +375,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
 

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -381,6 +381,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -375,6 +375,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -65,6 +65,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         // outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -71,6 +71,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -65,6 +65,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "brightness");
         // outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -366,6 +366,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)
@@ -3712,8 +3715,8 @@ int main(int argc, char **argv)
     elementsInRowMax = maxWidth * ip_channel;
 
     for (j = 0; j < noOfImages; j++)
-    {   
-        int height = dstSize[j].height; 
+    {
+        int height = dstSize[j].height;
         int width = dstSize[j].width;
 
         int op_size = height * width * ip_channel;
@@ -3730,15 +3733,15 @@ int main(int argc, char **argv)
             output_row += elementsInRowMax;
         }
         count += maxHeight * maxWidth * ip_channel;
-    
+
         char temp[1000];
         strcpy(temp, dst);
         strcat(temp, imageNames[j]);
-        
+
         Mat mat_op_image;
         mat_op_image = Mat(height, width, CV_8UC3, temp_output);
         imwrite(temp, mat_op_image);
-        
+
         free(temp_output);
     }
 

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -372,6 +372,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)
@@ -3580,10 +3583,10 @@ int main(int argc, char **argv)
     strcat(dst, "/");
     count = 0;
     elementsInRowMax = maxWidth * ip_channel;
-    
+
     for (j = 0; j < noOfImages; j++)
-    {   
-        int height = dstSize[j].height; 
+    {
+        int height = dstSize[j].height;
         int width = dstSize[j].width;
 
         int op_size = height * width * ip_channel;
@@ -3600,15 +3603,15 @@ int main(int argc, char **argv)
             output_row += elementsInRowMax;
         }
         count += maxHeight * maxWidth * ip_channel;
-    
+
         char temp[1000];
         strcpy(temp, dst);
         strcat(temp, imageNames[j]);
-        
+
         Mat mat_op_image;
         mat_op_image = Mat(height, width, CV_8UC1, temp_output);
         imwrite(temp, mat_op_image);
-        
+
         free(temp_output);
     }
     free(srcSize);

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -366,6 +366,9 @@ int main(int argc, char **argv)
     case 80:
         strcpy(funcName, "resize_mirror_normalize");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)
@@ -3818,8 +3821,8 @@ int main(int argc, char **argv)
     elementsInRowMax = maxWidth * ip_channel;
 
     for (j = 0; j < noOfImages; j++)
-    {   
-        int height = dstSize[j].height; 
+    {
+        int height = dstSize[j].height;
         int width = dstSize[j].width;
 
         int op_size = height * width * ip_channel;
@@ -3836,15 +3839,15 @@ int main(int argc, char **argv)
             output_row += elementsInRowMax;
         }
         count += maxHeight * maxWidth * ip_channel;
-    
+
         char temp[1000];
         strcpy(temp, dst);
         strcat(temp, imageNames[j]);
-        
+
         Mat mat_op_image;
         mat_op_image = Mat(height, width, CV_8UC3, temp_output);
         imwrite(temp, mat_op_image);
-        
+
         free(temp_output);
     }
     free(srcSize);

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -67,6 +67,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
@@ -73,6 +73,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
@@ -67,6 +67,9 @@ int main(int argc, char **argv)
     case 0:
         strcpy(funcName, "brightness");
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     // Initialize tensor descriptors

--- a/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pkd3.cpp
+++ b/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pkd3.cpp
@@ -365,6 +365,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
 

--- a/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pln1.cpp
+++ b/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pln1.cpp
@@ -372,6 +372,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (ip_bitDepth == 0)

--- a/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pln3.cpp
+++ b/utilities/rpp-unittests/OCL_NEW/BatchPD_ocl_pln3.cpp
@@ -367,6 +367,9 @@ int main(int argc, char **argv)
         strcpy(funcName, "remap");
         outputFormatToggle = 0;
         break;
+    default:
+        strcpy(funcName, "test_case");
+        break;
     }
 
     if (outputFormatToggle == 0)


### PR DESCRIPTION
@asalmanp @kiritigowda This is a minor common fix across all 30 test suite files for a "non-ascii" error.
To ensure no junk values are in the string, it adds a default assignment.