### PR TITLE
Warp Affine tensor HIP

### DIFF
--- a/include/rppdefs.h
+++ b/include/rppdefs.h
@@ -212,6 +212,16 @@ typedef enum
 
 } RpptRoiType;
 
+typedef enum
+{
+    NEAREST_NEIGHBOR = 0,
+    BILINEAR,
+    BICUBIC,
+    LANCZOS,
+    GAUSSIAN,
+    TRIANGULAR
+} RpptInterpolationType;
+
 typedef struct
 {
     RppiPoint lt, rb;

--- a/include/rppdefs.h
+++ b/include/rppdefs.h
@@ -105,6 +105,11 @@ typedef struct
     Rpp32u bufferMultiplier;
 } RppLayoutParams;
 
+typedef struct
+{
+    Rpp32f data[6];
+} Rpp32f6;
+
 
 
 

--- a/include/rppt_tensor_geometric_augmentations.h
+++ b/include/rppt_tensor_geometric_augmentations.h
@@ -45,6 +45,23 @@ extern "C" {
 RppStatus rppt_crop_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
 RppStatus rppt_crop_host(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
 
+/******************** warp_affine ********************/
+
+// Warp Affine augmentation for a NCHW/NHWC layout tensor
+
+// *param[in] srcPtr source tensor memory
+// *param[in] srcDesc source tensor descriptor
+// *param[out] dstPtr destination tensor memory
+// *param[in] dstDesc destination tensor descriptor
+// *param[in] affineTensor affine matrix values for transformation calculation (2D tensor of size batchSize * 6 for each image in batch)
+// *param[in] roiTensorSrc ROI data for each image in source tensor (2D tensor of size batchSize * 4, in either format - XYWH(xy.x, xy.y, roiWidth, roiHeight) or LTRB(lt.x, lt.y, rb.x, rb.y))
+// *param[in] roiType ROI type used (RpptRoiType::XYWH or RpptRoiType::LTRB)
+// *returns a  RppStatus enumeration.
+// *retval RPP_SUCCESS : succesful completion
+// *retval RPP_ERROR : Error
+
+RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, Rpp32f *affineTensor, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rppt_tensor_geometric_augmentations.h
+++ b/include/rppt_tensor_geometric_augmentations.h
@@ -54,13 +54,14 @@ RppStatus rppt_crop_host(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPt
 // *param[out] dstPtr destination tensor memory
 // *param[in] dstDesc destination tensor descriptor
 // *param[in] affineTensor affine matrix values for transformation calculation (2D tensor of size batchSize * 6 for each image in batch)
+// *param[in] interpolationType Interpolation type used (RpptInterpolationType::XYWH or RpptRoiType::LTRB)
 // *param[in] roiTensorSrc ROI data for each image in source tensor (2D tensor of size batchSize * 4, in either format - XYWH(xy.x, xy.y, roiWidth, roiHeight) or LTRB(lt.x, lt.y, rb.x, rb.y))
 // *param[in] roiType ROI type used (RpptRoiType::XYWH or RpptRoiType::LTRB)
 // *returns a  RppStatus enumeration.
 // *retval RPP_SUCCESS : succesful completion
 // *retval RPP_ERROR : Error
 
-RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, Rpp32f *affineTensor, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
+RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, Rpp32f *affineTensor, RpptInterpolationType interpolationType, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
 
 #ifdef __cplusplus
 }

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -627,12 +627,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3(u
     srcTempPtr += increment;
     src.z = *((uint2 *)(srcTempPtr));
 
-    src_f24->x.x = rpp_hip_unpack(src.x.x);
-    src_f24->x.y = rpp_hip_unpack(src.x.y);
-    src_f24->y.x = rpp_hip_unpack(src.y.x);
-    src_f24->y.y = rpp_hip_unpack(src.y.y);
-    src_f24->z.x = rpp_hip_unpack(src.z.x);
-    src_f24->z.y = rpp_hip_unpack(src.z.y);
+    src_f24->x.x = rpp_hip_unpack(src.x.x);    // write R00-R03
+    src_f24->x.y = rpp_hip_unpack(src.x.y);    // write R04-R07
+    src_f24->y.x = rpp_hip_unpack(src.y.x);    // write G00-G03
+    src_f24->y.y = rpp_hip_unpack(src.y.y);    // write G04-G07
+    src_f24->z.x = rpp_hip_unpack(src.z.x);    // write B00-B03
+    src_f24->z.y = rpp_hip_unpack(src.z.y);    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_mirror(uchar *srcPtr, uint increment, d_float24 *src_f24)
@@ -646,12 +646,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_m
     srcTempPtr += increment;
     src.z = *((uint2 *)(srcTempPtr));
 
-    src_f24->x.x = rpp_hip_unpack_mirror(src.x.y);
-    src_f24->x.y = rpp_hip_unpack_mirror(src.x.x);
-    src_f24->y.x = rpp_hip_unpack_mirror(src.y.y);
-    src_f24->y.y = rpp_hip_unpack_mirror(src.y.x);
-    src_f24->z.x = rpp_hip_unpack_mirror(src.z.y);
-    src_f24->z.y = rpp_hip_unpack_mirror(src.z.x);
+    src_f24->x.x = rpp_hip_unpack_mirror(src.x.y);    // write R07-R04 (mirrored load)
+    src_f24->x.y = rpp_hip_unpack_mirror(src.x.x);    // write R03-R00 (mirrored load)
+    src_f24->y.x = rpp_hip_unpack_mirror(src.y.y);    // write G07-G04 (mirrored load)
+    src_f24->y.y = rpp_hip_unpack_mirror(src.y.x);    // write G03-G00 (mirrored load)
+    src_f24->z.x = rpp_hip_unpack_mirror(src.z.y);    // write B07-B04 (mirrored load)
+    src_f24->z.y = rpp_hip_unpack_mirror(src.z.x);    // write B03-B00 (mirrored load)
 }
 
 // F32 loads without layout toggle PLN3 to PLN3 (24 F32 pixels)
@@ -663,9 +663,9 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3(f
     srcPtrG = srcPtrR + increment;
     srcPtrB = srcPtrG + increment;
 
-    src_f24->x = *(d_float8 *)srcPtrR;
-    src_f24->y = *(d_float8 *)srcPtrG;
-    src_f24->z = *(d_float8 *)srcPtrB;
+    src_f24->x = *(d_float8 *)srcPtrR;    // write R00-R07
+    src_f24->y = *(d_float8 *)srcPtrG;    // write G00-G07
+    src_f24->z = *(d_float8 *)srcPtrB;    // write B00-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_mirror(float *srcPtr, uint increment, d_float24 *src_f24)
@@ -680,12 +680,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_m
     src.y = *(d_float8 *)srcPtrG;
     src.z = *(d_float8 *)srcPtrB;
 
-    src_f24->x.x = rpp_hip_unpack_mirror(src.x.y);
-    src_f24->x.y = rpp_hip_unpack_mirror(src.x.x);
-    src_f24->y.x = rpp_hip_unpack_mirror(src.y.y);
-    src_f24->y.y = rpp_hip_unpack_mirror(src.y.x);
-    src_f24->z.x = rpp_hip_unpack_mirror(src.z.y);
-    src_f24->z.y = rpp_hip_unpack_mirror(src.z.x);
+    src_f24->x.x = rpp_hip_unpack_mirror(src.x.y);    // write R07-R04 (mirrored load)
+    src_f24->x.y = rpp_hip_unpack_mirror(src.x.x);    // write R03-R00 (mirrored load)
+    src_f24->y.x = rpp_hip_unpack_mirror(src.y.y);    // write G07-G04 (mirrored load)
+    src_f24->y.y = rpp_hip_unpack_mirror(src.y.x);    // write G03-G00 (mirrored load)
+    src_f24->z.x = rpp_hip_unpack_mirror(src.z.y);    // write B07-B04 (mirrored load)
+    src_f24->z.y = rpp_hip_unpack_mirror(src.z.x);    // write B03-B00 (mirrored load)
 }
 
 // I8 loads without layout toggle PLN3 to PLN3 (24 I8 pixels)
@@ -701,12 +701,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3(s
     srcTempPtr += increment;
     src.z = *((int2 *)(srcTempPtr));
 
-    src_f24->x.x = rpp_hip_unpack_from_i8(src.x.x);
-    src_f24->x.y = rpp_hip_unpack_from_i8(src.x.y);
-    src_f24->y.x = rpp_hip_unpack_from_i8(src.y.x);
-    src_f24->y.y = rpp_hip_unpack_from_i8(src.y.y);
-    src_f24->z.x = rpp_hip_unpack_from_i8(src.z.x);
-    src_f24->z.y = rpp_hip_unpack_from_i8(src.z.y);
+    src_f24->x.x = rpp_hip_unpack_from_i8(src.x.x);    // write R00-R03
+    src_f24->x.y = rpp_hip_unpack_from_i8(src.x.y);    // write R04-R07
+    src_f24->y.x = rpp_hip_unpack_from_i8(src.y.x);    // write G00-G03
+    src_f24->y.y = rpp_hip_unpack_from_i8(src.y.y);    // write G04-G07
+    src_f24->z.x = rpp_hip_unpack_from_i8(src.z.x);    // write B00-B03
+    src_f24->z.y = rpp_hip_unpack_from_i8(src.z.y);    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_mirror(schar *srcPtr, uint increment, d_float24 *src_f24)
@@ -720,12 +720,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_m
     srcTempPtr += increment;
     src.z = *((int2 *)(srcTempPtr));
 
-    src_f24->x.x = rpp_hip_unpack_from_i8_mirror(src.x.y);
-    src_f24->x.y = rpp_hip_unpack_from_i8_mirror(src.x.x);
-    src_f24->y.x = rpp_hip_unpack_from_i8_mirror(src.y.y);
-    src_f24->y.y = rpp_hip_unpack_from_i8_mirror(src.y.x);
-    src_f24->z.x = rpp_hip_unpack_from_i8_mirror(src.z.y);
-    src_f24->z.y = rpp_hip_unpack_from_i8_mirror(src.z.x);
+    src_f24->x.x = rpp_hip_unpack_from_i8_mirror(src.x.y);    // write R07-R04 (mirrored load)
+    src_f24->x.y = rpp_hip_unpack_from_i8_mirror(src.x.x);    // write R03-R00 (mirrored load)
+    src_f24->y.x = rpp_hip_unpack_from_i8_mirror(src.y.y);    // write G07-G04 (mirrored load)
+    src_f24->y.y = rpp_hip_unpack_from_i8_mirror(src.y.x);    // write G03-G00 (mirrored load)
+    src_f24->z.x = rpp_hip_unpack_from_i8_mirror(src.z.y);    // write B07-B04 (mirrored load)
+    src_f24->z.y = rpp_hip_unpack_from_i8_mirror(src.z.x);    // write B03-B00 (mirrored load)
 }
 
 // F16 loads without layout toggle PLN3 to PLN3 (24 F16 pixels)
@@ -742,32 +742,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3(h
     srcG_h8 = (d_half8 *)srcPtrG;
     srcB_h8 = (d_half8 *)srcPtrB;
 
-    src_f24->x.x.x = __half2float(__low2half(srcR_h8->x.x));
-    src_f24->x.x.y = __half2float(__high2half(srcR_h8->x.x));
-    src_f24->x.x.z = __half2float(__low2half(srcR_h8->x.y));
-    src_f24->x.x.w = __half2float(__high2half(srcR_h8->x.y));
-    src_f24->x.y.x = __half2float(__low2half(srcR_h8->y.x));
-    src_f24->x.y.y = __half2float(__high2half(srcR_h8->y.x));
-    src_f24->x.y.z = __half2float(__low2half(srcR_h8->y.y));
-    src_f24->x.y.w = __half2float(__high2half(srcR_h8->y.y));
-
-    src_f24->y.x.x = __half2float(__low2half(srcG_h8->x.x));
-    src_f24->y.x.y = __half2float(__high2half(srcG_h8->x.x));
-    src_f24->y.x.z = __half2float(__low2half(srcG_h8->x.y));
-    src_f24->y.x.w = __half2float(__high2half(srcG_h8->x.y));
-    src_f24->y.y.x = __half2float(__low2half(srcG_h8->y.x));
-    src_f24->y.y.y = __half2float(__high2half(srcG_h8->y.x));
-    src_f24->y.y.z = __half2float(__low2half(srcG_h8->y.y));
-    src_f24->y.y.w = __half2float(__high2half(srcG_h8->y.y));
-
-    src_f24->z.x.x = __half2float(__low2half(srcB_h8->x.x));
-    src_f24->z.x.y = __half2float(__high2half(srcB_h8->x.x));
-    src_f24->z.x.z = __half2float(__low2half(srcB_h8->x.y));
-    src_f24->z.x.w = __half2float(__high2half(srcB_h8->x.y));
-    src_f24->z.y.x = __half2float(__low2half(srcB_h8->y.x));
-    src_f24->z.y.y = __half2float(__high2half(srcB_h8->y.x));
-    src_f24->z.y.z = __half2float(__low2half(srcB_h8->y.y));
-    src_f24->z.y.w = __half2float(__high2half(srcB_h8->y.y));
+    src_f24->x.x = make_float4(__half2float(__low2half(srcR_h8->x.x)), __half2float(__high2half(srcR_h8->x.x)), __half2float(__low2half(srcR_h8->x.y)), __half2float(__high2half(srcR_h8->x.y)));    // write R00-R03
+    src_f24->x.y = make_float4(__half2float(__low2half(srcR_h8->y.x)), __half2float(__high2half(srcR_h8->y.x)), __half2float(__low2half(srcR_h8->y.y)), __half2float(__high2half(srcR_h8->y.y)));    // write R04-R07
+    src_f24->y.x = make_float4(__half2float(__low2half(srcG_h8->x.x)), __half2float(__high2half(srcG_h8->x.x)), __half2float(__low2half(srcG_h8->x.y)), __half2float(__high2half(srcG_h8->x.y)));    // write G00-G03
+    src_f24->y.y = make_float4(__half2float(__low2half(srcG_h8->y.x)), __half2float(__high2half(srcG_h8->y.x)), __half2float(__low2half(srcG_h8->y.y)), __half2float(__high2half(srcG_h8->y.y)));    // write G04-G07
+    src_f24->z.x = make_float4(__half2float(__low2half(srcB_h8->x.x)), __half2float(__high2half(srcB_h8->x.x)), __half2float(__low2half(srcB_h8->x.y)), __half2float(__high2half(srcB_h8->x.y)));    // write B00-B03
+    src_f24->z.y = make_float4(__half2float(__low2half(srcB_h8->y.x)), __half2float(__high2half(srcB_h8->y.x)), __half2float(__low2half(srcB_h8->y.y)), __half2float(__high2half(srcB_h8->y.y)));    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_mirror(half *srcPtr, uint increment, d_float24 *src_f24)
@@ -782,32 +762,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pln3_m
     srcG_h8 = (d_half8 *)srcPtrG;
     srcB_h8 = (d_half8 *)srcPtrB;
 
-    src_f24->x.x.x = __half2float(__high2half(srcR_h8->y.y));
-    src_f24->x.x.y = __half2float(__low2half(srcR_h8->y.y));
-    src_f24->x.x.z = __half2float(__high2half(srcR_h8->y.x));
-    src_f24->x.x.w = __half2float(__low2half(srcR_h8->y.x));
-    src_f24->x.y.x = __half2float(__high2half(srcR_h8->x.y));
-    src_f24->x.y.y = __half2float(__low2half(srcR_h8->x.y));
-    src_f24->x.y.z = __half2float(__high2half(srcR_h8->x.x));
-    src_f24->x.y.w = __half2float(__low2half(srcR_h8->x.x));
-
-    src_f24->y.x.x = __half2float(__high2half(srcG_h8->y.y));
-    src_f24->y.x.y = __half2float(__low2half(srcG_h8->y.y));
-    src_f24->y.x.z = __half2float(__high2half(srcG_h8->y.x));
-    src_f24->y.x.w = __half2float(__low2half(srcG_h8->y.x));
-    src_f24->y.y.x = __half2float(__high2half(srcG_h8->x.y));
-    src_f24->y.y.y = __half2float(__low2half(srcG_h8->x.y));
-    src_f24->y.y.z = __half2float(__high2half(srcG_h8->x.x));
-    src_f24->y.y.w = __half2float(__low2half(srcG_h8->x.x));
-
-    src_f24->z.x.x = __half2float(__high2half(srcB_h8->y.y));
-    src_f24->z.x.y = __half2float(__low2half(srcB_h8->y.y));
-    src_f24->z.x.z = __half2float(__high2half(srcB_h8->y.x));
-    src_f24->z.x.w = __half2float(__low2half(srcB_h8->y.x));
-    src_f24->z.y.x = __half2float(__high2half(srcB_h8->x.y));
-    src_f24->z.y.y = __half2float(__low2half(srcB_h8->x.y));
-    src_f24->z.y.z = __half2float(__high2half(srcB_h8->x.x));
-    src_f24->z.y.w = __half2float(__low2half(srcB_h8->x.x));
+    src_f24->x.x = make_float4(__half2float(__high2half(srcR_h8->y.y)), __half2float(__low2half(srcR_h8->y.y)), __half2float(__high2half(srcR_h8->y.x)), __half2float(__low2half(srcR_h8->y.x)));    // write R07-R04 (mirrored load)
+    src_f24->x.y = make_float4(__half2float(__high2half(srcR_h8->x.y)), __half2float(__low2half(srcR_h8->x.y)), __half2float(__high2half(srcR_h8->x.x)), __half2float(__low2half(srcR_h8->x.x)));    // write R03-R00 (mirrored load)
+    src_f24->y.x = make_float4(__half2float(__high2half(srcG_h8->y.y)), __half2float(__low2half(srcG_h8->y.y)), __half2float(__high2half(srcG_h8->y.x)), __half2float(__low2half(srcG_h8->y.x)));    // write G07-G04 (mirrored load)
+    src_f24->y.y = make_float4(__half2float(__high2half(srcG_h8->x.y)), __half2float(__low2half(srcG_h8->x.y)), __half2float(__high2half(srcG_h8->x.x)), __half2float(__low2half(srcG_h8->x.x)));    // write G03-G00 (mirrored load)
+    src_f24->z.x = make_float4(__half2float(__high2half(srcB_h8->y.y)), __half2float(__low2half(srcB_h8->y.y)), __half2float(__high2half(srcB_h8->y.x)), __half2float(__low2half(srcB_h8->y.x)));    // write B07-B04 (mirrored load)
+    src_f24->z.y = make_float4(__half2float(__high2half(srcB_h8->x.y)), __half2float(__low2half(srcB_h8->x.y)), __half2float(__high2half(srcB_h8->x.x)), __half2float(__low2half(srcB_h8->x.x)));    // write B03-B00 (mirrored load)
 }
 
 // WITH LAYOUT TOGGLE
@@ -818,28 +778,24 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(u
 {
     d_uint6 src = *((d_uint6 *)(srcPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack1(src.y.x));
-    src_f24->x.y = make_float4(rpp_hip_unpack0(src.y.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack1(src.z.y));
-
-    src_f24->y.x = make_float4(rpp_hip_unpack1(src.x.x), rpp_hip_unpack0(src.x.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack2(src.y.x));
-    src_f24->y.y = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack0(src.z.x), rpp_hip_unpack3(src.z.x), rpp_hip_unpack2(src.z.y));
-
-    src_f24->z.x = make_float4(rpp_hip_unpack2(src.x.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack0(src.y.x), rpp_hip_unpack3(src.y.x));
-    src_f24->z.y = make_float4(rpp_hip_unpack2(src.y.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack0(src.z.y), rpp_hip_unpack3(src.z.y));
+    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack1(src.y.x));    // write R00-R03
+    src_f24->x.y = make_float4(rpp_hip_unpack0(src.y.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack1(src.z.y));    // write R04-R07
+    src_f24->y.x = make_float4(rpp_hip_unpack1(src.x.x), rpp_hip_unpack0(src.x.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack2(src.y.x));    // write G00-G03
+    src_f24->y.y = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack0(src.z.x), rpp_hip_unpack3(src.z.x), rpp_hip_unpack2(src.z.y));    // write G04-G07
+    src_f24->z.x = make_float4(rpp_hip_unpack2(src.x.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack0(src.y.x), rpp_hip_unpack3(src.y.x));    // write B00-B03
+    src_f24->z.y = make_float4(rpp_hip_unpack2(src.y.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack0(src.z.y), rpp_hip_unpack3(src.z.y));    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_mirror(uchar *srcPtr, d_float24 *src_f24)
 {
     d_uint6 src = *((d_uint6 *)(srcPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.y.y), rpp_hip_unpack0(src.y.y));
-    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack3(src.x.x), rpp_hip_unpack0(src.x.x));
-
-    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.z.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.y.y));
-    src_f24->y.y = make_float4(rpp_hip_unpack2(src.y.x), rpp_hip_unpack3(src.x.y), rpp_hip_unpack0(src.x.y), rpp_hip_unpack1(src.x.x));
-
-    src_f24->z.x = make_float4(rpp_hip_unpack3(src.z.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.y.y));
-    src_f24->z.y = make_float4(rpp_hip_unpack3(src.y.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack2(src.x.x));
+    src_f24->x.x = make_float4(rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.y.y), rpp_hip_unpack0(src.y.y));    // write R07-R04 (mirrored load)
+    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack3(src.x.x), rpp_hip_unpack0(src.x.x));    // write R03-R00 (mirrored load)
+    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.z.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.y.y));    // write G07-G04 (mirrored load)
+    src_f24->y.y = make_float4(rpp_hip_unpack2(src.y.x), rpp_hip_unpack3(src.x.y), rpp_hip_unpack0(src.x.y), rpp_hip_unpack1(src.x.x));    // write G03-G00 (mirrored load)
+    src_f24->z.x = make_float4(rpp_hip_unpack3(src.z.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.y.y));    // write B07-B04 (mirrored load)
+    src_f24->z.y = make_float4(rpp_hip_unpack3(src.y.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack2(src.x.x));    // write B03-B00 (mirrored load)
 }
 
 // F32 loads with layout toggle PKD3 to PLN3 (24 F32 pixels)
@@ -849,32 +805,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(f
     d_float24 *srcPtr_f24;
     srcPtr_f24 = (d_float24 *)srcPtr;
 
-    src_f24->x.x.x = srcPtr_f24->x.x.x;
-    src_f24->x.x.y = srcPtr_f24->x.x.w;
-    src_f24->x.x.z = srcPtr_f24->x.y.z;
-    src_f24->x.x.w = srcPtr_f24->y.x.y;
-    src_f24->x.y.x = srcPtr_f24->y.y.x;
-    src_f24->x.y.y = srcPtr_f24->y.y.w;
-    src_f24->x.y.z = srcPtr_f24->z.x.z;
-    src_f24->x.y.w = srcPtr_f24->z.y.y;
-
-    src_f24->y.x.x = srcPtr_f24->x.x.y;
-    src_f24->y.x.y = srcPtr_f24->x.y.x;
-    src_f24->y.x.z = srcPtr_f24->x.y.w;
-    src_f24->y.x.w = srcPtr_f24->y.x.z;
-    src_f24->y.y.x = srcPtr_f24->y.y.y;
-    src_f24->y.y.y = srcPtr_f24->z.x.x;
-    src_f24->y.y.z = srcPtr_f24->z.x.w;
-    src_f24->y.y.w = srcPtr_f24->z.y.z;
-
-    src_f24->z.x.x = srcPtr_f24->x.x.z;
-    src_f24->z.x.y = srcPtr_f24->x.y.y;
-    src_f24->z.x.z = srcPtr_f24->y.x.x;
-    src_f24->z.x.w = srcPtr_f24->y.x.w;
-    src_f24->z.y.x = srcPtr_f24->y.y.z;
-    src_f24->z.y.y = srcPtr_f24->z.x.y;
-    src_f24->z.y.z = srcPtr_f24->z.y.x;
-    src_f24->z.y.w = srcPtr_f24->z.y.w;
+    src_f24->x.x = make_float4(srcPtr_f24->x.x.x, srcPtr_f24->x.x.w, srcPtr_f24->x.y.z, srcPtr_f24->y.x.y);    // write R00-R03
+    src_f24->x.y = make_float4(srcPtr_f24->y.y.x, srcPtr_f24->y.y.w, srcPtr_f24->z.x.z, srcPtr_f24->z.y.y);    // write R04-R07
+    src_f24->y.x = make_float4(srcPtr_f24->x.x.y, srcPtr_f24->x.y.x, srcPtr_f24->x.y.w, srcPtr_f24->y.x.z);    // write G00-G03
+    src_f24->y.y = make_float4(srcPtr_f24->y.y.y, srcPtr_f24->z.x.x, srcPtr_f24->z.x.w, srcPtr_f24->z.y.z);    // write G04-G07
+    src_f24->z.x = make_float4(srcPtr_f24->x.x.z, srcPtr_f24->x.y.y, srcPtr_f24->y.x.x, srcPtr_f24->y.x.w);    // write B00-B03
+    src_f24->z.y = make_float4(srcPtr_f24->y.y.z, srcPtr_f24->z.x.y, srcPtr_f24->z.y.x, srcPtr_f24->z.y.w);    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_mirror(float *srcPtr, d_float24 *src_f24)
@@ -882,32 +818,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_m
     d_float24 *srcPtr_f24;
     srcPtr_f24 = (d_float24 *)srcPtr;
 
-    src_f24->x.x.x = srcPtr_f24->z.y.y;
-    src_f24->x.x.y = srcPtr_f24->z.x.z;
-    src_f24->x.x.z = srcPtr_f24->y.y.w;
-    src_f24->x.x.w = srcPtr_f24->y.y.x;
-    src_f24->x.y.x = srcPtr_f24->y.x.y;
-    src_f24->x.y.y = srcPtr_f24->x.y.z;
-    src_f24->x.y.z = srcPtr_f24->x.x.w;
-    src_f24->x.y.w = srcPtr_f24->x.x.x;
-
-    src_f24->y.x.x = srcPtr_f24->z.y.z;
-    src_f24->y.x.y = srcPtr_f24->z.x.w;
-    src_f24->y.x.z = srcPtr_f24->z.x.x;
-    src_f24->y.x.w = srcPtr_f24->y.y.y;
-    src_f24->y.y.x = srcPtr_f24->y.x.z;
-    src_f24->y.y.y = srcPtr_f24->x.y.w;
-    src_f24->y.y.z = srcPtr_f24->x.y.x;
-    src_f24->y.y.w = srcPtr_f24->x.x.y;
-
-    src_f24->z.x.x = srcPtr_f24->z.y.w;
-    src_f24->z.x.y = srcPtr_f24->z.y.x;
-    src_f24->z.x.z = srcPtr_f24->z.x.y;
-    src_f24->z.x.w = srcPtr_f24->y.y.z;
-    src_f24->z.y.x = srcPtr_f24->y.x.w;
-    src_f24->z.y.y = srcPtr_f24->y.x.x;
-    src_f24->z.y.z = srcPtr_f24->x.y.y;
-    src_f24->z.y.w = srcPtr_f24->x.x.z;
+    src_f24->x.x = make_float4(srcPtr_f24->z.y.y, srcPtr_f24->z.x.z, srcPtr_f24->y.y.w, srcPtr_f24->y.y.x);    // write R07-R04 (mirrored load)
+    src_f24->x.y = make_float4(srcPtr_f24->y.x.y, srcPtr_f24->x.y.z, srcPtr_f24->x.x.w, srcPtr_f24->x.x.x);    // write R03-R00 (mirrored load)
+    src_f24->y.x = make_float4(srcPtr_f24->z.y.z, srcPtr_f24->z.x.w, srcPtr_f24->z.x.x, srcPtr_f24->y.y.y);    // write G07-G04 (mirrored load)
+    src_f24->y.y = make_float4(srcPtr_f24->y.x.z, srcPtr_f24->x.y.w, srcPtr_f24->x.y.x, srcPtr_f24->x.x.y);    // write G03-G00 (mirrored load)
+    src_f24->z.x = make_float4(srcPtr_f24->z.y.w, srcPtr_f24->z.y.x, srcPtr_f24->z.x.y, srcPtr_f24->y.y.z);    // write B07-B04 (mirrored load)
+    src_f24->z.y = make_float4(srcPtr_f24->y.x.w, srcPtr_f24->y.x.x, srcPtr_f24->x.y.y, srcPtr_f24->x.x.z);    // write B03-B00 (mirrored load)
 }
 
 // I8 loads with layout toggle PKD3 to PLN3 (24 I8 pixels)
@@ -916,28 +832,24 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(s
 {
     d_int6 src = *((d_int6 *)(srcPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack1(src.y.x));
-    src_f24->x.y = make_float4(rpp_hip_unpack0(src.y.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack1(src.z.y));
-
-    src_f24->y.x = make_float4(rpp_hip_unpack1(src.x.x), rpp_hip_unpack0(src.x.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack2(src.y.x));
-    src_f24->y.y = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack0(src.z.x), rpp_hip_unpack3(src.z.x), rpp_hip_unpack2(src.z.y));
-
-    src_f24->z.x = make_float4(rpp_hip_unpack2(src.x.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack0(src.y.x), rpp_hip_unpack3(src.y.x));
-    src_f24->z.y = make_float4(rpp_hip_unpack2(src.y.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack0(src.z.y), rpp_hip_unpack3(src.z.y));
+    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack1(src.y.x));    // write R00-R03
+    src_f24->x.y = make_float4(rpp_hip_unpack0(src.y.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack1(src.z.y));    // write R04-R07
+    src_f24->y.x = make_float4(rpp_hip_unpack1(src.x.x), rpp_hip_unpack0(src.x.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack2(src.y.x));    // write G00-G03
+    src_f24->y.y = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack0(src.z.x), rpp_hip_unpack3(src.z.x), rpp_hip_unpack2(src.z.y));    // write G04-G07
+    src_f24->z.x = make_float4(rpp_hip_unpack2(src.x.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack0(src.y.x), rpp_hip_unpack3(src.y.x));    // write B00-B03
+    src_f24->z.y = make_float4(rpp_hip_unpack2(src.y.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack0(src.z.y), rpp_hip_unpack3(src.z.y));    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_mirror(schar *srcPtr, d_float24 *src_f24)
 {
     d_int6 src = *((d_int6 *)(srcPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.y.y), rpp_hip_unpack0(src.y.y));
-    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack3(src.x.x), rpp_hip_unpack0(src.x.x));
-
-    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.z.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.y.y));
-    src_f24->y.y = make_float4(rpp_hip_unpack2(src.y.x), rpp_hip_unpack3(src.x.y), rpp_hip_unpack0(src.x.y), rpp_hip_unpack1(src.x.x));
-
-    src_f24->z.x = make_float4(rpp_hip_unpack3(src.z.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.y.y));
-    src_f24->z.y = make_float4(rpp_hip_unpack3(src.y.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack2(src.x.x));
+    src_f24->x.x = make_float4(rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.y.y), rpp_hip_unpack0(src.y.y));    // write R07-R04 (mirrored load)
+    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack2(src.x.y), rpp_hip_unpack3(src.x.x), rpp_hip_unpack0(src.x.x));    // write R03-R00 (mirrored load)
+    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.z.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.y.y));    // write G07-G04 (mirrored load)
+    src_f24->y.y = make_float4(rpp_hip_unpack2(src.y.x), rpp_hip_unpack3(src.x.y), rpp_hip_unpack0(src.x.y), rpp_hip_unpack1(src.x.x));    // write G03-G00 (mirrored load)
+    src_f24->z.x = make_float4(rpp_hip_unpack3(src.z.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.y.y));    // write B07-B04 (mirrored load)
+    src_f24->z.y = make_float4(rpp_hip_unpack3(src.y.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack1(src.x.y), rpp_hip_unpack2(src.x.x));    // write B03-B00 (mirrored load)
 }
 
 // F16 loads with layout toggle PKD3 to PLN3 (24 F16 pixels)
@@ -947,32 +859,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(h
     d_half24 *src_h24;
     src_h24 = (d_half24 *)srcPtr;
 
-    src_f24->x.x.x = __half2float(__low2half(src_h24->x.x.x));
-    src_f24->x.x.y = __half2float(__high2half(src_h24->x.x.y));
-    src_f24->x.x.z = __half2float(__low2half(src_h24->x.y.y));
-    src_f24->x.x.w = __half2float(__high2half(src_h24->y.x.x));
-    src_f24->x.y.x = __half2float(__low2half(src_h24->y.y.x));
-    src_f24->x.y.y = __half2float(__high2half(src_h24->y.y.y));
-    src_f24->x.y.z = __half2float(__low2half(src_h24->z.x.y));
-    src_f24->x.y.w = __half2float(__high2half(src_h24->z.y.x));
-
-    src_f24->y.x.x = __half2float(__high2half(src_h24->x.x.x));
-    src_f24->y.x.y = __half2float(__low2half(src_h24->x.y.x));
-    src_f24->y.x.z = __half2float(__high2half(src_h24->x.y.y));
-    src_f24->y.x.w = __half2float(__low2half(src_h24->y.x.y));
-    src_f24->y.y.x = __half2float(__high2half(src_h24->y.y.x));
-    src_f24->y.y.y = __half2float(__low2half(src_h24->z.x.x));
-    src_f24->y.y.z = __half2float(__high2half(src_h24->z.x.y));
-    src_f24->y.y.w = __half2float(__low2half(src_h24->z.y.y));
-
-    src_f24->z.x.x = __half2float(__low2half(src_h24->x.x.y));
-    src_f24->z.x.y = __half2float(__high2half(src_h24->x.y.x));
-    src_f24->z.x.z = __half2float(__low2half(src_h24->y.x.x));
-    src_f24->z.x.w = __half2float(__high2half(src_h24->y.x.y));
-    src_f24->z.y.x = __half2float(__low2half(src_h24->y.y.y));
-    src_f24->z.y.y = __half2float(__high2half(src_h24->z.x.x));
-    src_f24->z.y.z = __half2float(__low2half(src_h24->z.y.x));
-    src_f24->z.y.w = __half2float(__high2half(src_h24->z.y.y));
+    src_f24->x.x = make_float4(__half2float(__low2half(src_h24->x.x.x)), __half2float(__high2half(src_h24->x.x.y)), __half2float(__low2half(src_h24->x.y.y)), __half2float(__high2half(src_h24->y.x.x)));    // write R00-R03
+    src_f24->x.y = make_float4(__half2float(__low2half(src_h24->y.y.x)), __half2float(__high2half(src_h24->y.y.y)), __half2float(__low2half(src_h24->z.x.y)), __half2float(__high2half(src_h24->z.y.x)));    // write R04-R07
+    src_f24->y.x = make_float4(__half2float(__high2half(src_h24->x.x.x)), __half2float(__low2half(src_h24->x.y.x)), __half2float(__high2half(src_h24->x.y.y)), __half2float(__low2half(src_h24->y.x.y)));    // write G00-G03
+    src_f24->y.y = make_float4(__half2float(__high2half(src_h24->y.y.x)), __half2float(__low2half(src_h24->z.x.x)), __half2float(__high2half(src_h24->z.x.y)), __half2float(__low2half(src_h24->z.y.y)));    // write G04-G07
+    src_f24->z.x = make_float4(__half2float(__low2half(src_h24->x.x.y)), __half2float(__high2half(src_h24->x.y.x)), __half2float(__low2half(src_h24->y.x.x)), __half2float(__high2half(src_h24->y.x.y)));    // write B00-B03
+    src_f24->z.y = make_float4(__half2float(__low2half(src_h24->y.y.y)), __half2float(__high2half(src_h24->z.x.x)), __half2float(__low2half(src_h24->z.y.x)), __half2float(__high2half(src_h24->z.y.y)));    // write B04-B07
 }
 
 __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_mirror(half *srcPtr, d_float24 *src_f24)
@@ -980,32 +872,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_and_unpack_to_float24_pln3_m
     d_half24 *src_h24;
     src_h24 = (d_half24 *)srcPtr;
 
-    src_f24->x.x.x = __half2float(__high2half(src_h24->z.y.x));
-    src_f24->x.x.y = __half2float(__low2half(src_h24->z.x.y));
-    src_f24->x.x.z = __half2float(__high2half(src_h24->y.y.y));
-    src_f24->x.x.w = __half2float(__low2half(src_h24->y.y.x));
-    src_f24->x.y.x = __half2float(__high2half(src_h24->y.x.x));
-    src_f24->x.y.y = __half2float(__low2half(src_h24->x.y.y));
-    src_f24->x.y.z = __half2float(__high2half(src_h24->x.x.y));
-    src_f24->x.y.w = __half2float(__low2half(src_h24->x.x.x));
-
-    src_f24->y.x.x = __half2float(__low2half(src_h24->z.y.y));
-    src_f24->y.x.y = __half2float(__high2half(src_h24->z.x.y));
-    src_f24->y.x.z = __half2float(__low2half(src_h24->z.x.x));
-    src_f24->y.x.w = __half2float(__high2half(src_h24->y.y.x));
-    src_f24->y.y.x = __half2float(__low2half(src_h24->y.x.y));
-    src_f24->y.y.y = __half2float(__high2half(src_h24->x.y.y));
-    src_f24->y.y.z = __half2float(__low2half(src_h24->x.y.x));
-    src_f24->y.y.w = __half2float(__high2half(src_h24->x.x.x));
-
-    src_f24->z.x.x = __half2float(__high2half(src_h24->z.y.y));
-    src_f24->z.x.y = __half2float(__low2half(src_h24->z.y.x));
-    src_f24->z.x.z = __half2float(__high2half(src_h24->z.x.x));
-    src_f24->z.x.w = __half2float(__low2half(src_h24->y.y.y));
-    src_f24->z.y.x = __half2float(__high2half(src_h24->y.x.y));
-    src_f24->z.y.y = __half2float(__low2half(src_h24->y.x.x));
-    src_f24->z.y.z = __half2float(__high2half(src_h24->x.y.x));
-    src_f24->z.y.w = __half2float(__low2half(src_h24->x.x.y));
+    src_f24->x.x = make_float4(__half2float(__high2half(src_h24->z.y.x)), __half2float(__low2half(src_h24->z.x.y)), __half2float(__high2half(src_h24->y.y.y)), __half2float(__low2half(src_h24->y.y.x)));    // write R07-R04 (mirrored load)
+    src_f24->x.y = make_float4(__half2float(__high2half(src_h24->y.x.x)), __half2float(__low2half(src_h24->x.y.y)), __half2float(__high2half(src_h24->x.x.y)), __half2float(__low2half(src_h24->x.x.x)));    // write R03-R00 (mirrored load)
+    src_f24->y.x = make_float4(__half2float(__low2half(src_h24->z.y.y)), __half2float(__high2half(src_h24->z.x.y)), __half2float(__low2half(src_h24->z.x.x)), __half2float(__high2half(src_h24->y.y.x)));    // write G07-G04 (mirrored load)
+    src_f24->y.y = make_float4(__half2float(__low2half(src_h24->y.x.y)), __half2float(__high2half(src_h24->x.y.y)), __half2float(__low2half(src_h24->x.y.x)), __half2float(__high2half(src_h24->x.x.x)));    // write G03-G00 (mirrored load)
+    src_f24->z.x = make_float4(__half2float(__high2half(src_h24->z.y.y)), __half2float(__low2half(src_h24->z.y.x)), __half2float(__high2half(src_h24->z.x.x)), __half2float(__low2half(src_h24->y.y.y)));    // write B07-B04 (mirrored load)
+    src_f24->z.y = make_float4(__half2float(__high2half(src_h24->y.x.y)), __half2float(__low2half(src_h24->y.x.x)), __half2float(__high2half(src_h24->x.y.x)), __half2float(__low2half(src_h24->x.x.y)));    // write B03-B00 (mirrored load)
 }
 
 // U8 loads with layout toggle PLN3 to PKD3 (24 U8 pixels)
@@ -1021,12 +893,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pkd3(u
     srcTempPtr += increment;
     src.z = *((uint2 *)(srcTempPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.x.x));
-    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.x.x), rpp_hip_unpack2(src.y.x));
-    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack3(src.y.x), rpp_hip_unpack3(src.z.x));
-    src_f24->y.y = make_float4(rpp_hip_unpack0(src.x.y), rpp_hip_unpack0(src.y.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.x.y));
-    src_f24->z.x = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.x.y), rpp_hip_unpack2(src.y.y));
-    src_f24->z.y = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack3(src.z.y));
+    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.x.x));    // write R00G00B00R01
+    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.x.x), rpp_hip_unpack2(src.y.x));    // write G01B01R02G02
+    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack3(src.y.x), rpp_hip_unpack3(src.z.x));    // write B02R03G03B03
+    src_f24->y.y = make_float4(rpp_hip_unpack0(src.x.y), rpp_hip_unpack0(src.y.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.x.y));    // write R04G04B04R05
+    src_f24->z.x = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.x.y), rpp_hip_unpack2(src.y.y));    // write G05B05R06G06
+    src_f24->z.y = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack3(src.z.y));    // write B06R07G07B07
 }
 
 // F32 loads with layout toggle PLN3 to PKD3 (24 F32 pixels)
@@ -1044,37 +916,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pkd3(f
     srcPtrG_f8 = (d_float8 *)srcPtrG;
     srcPtrB_f8 = (d_float8 *)srcPtrB;
 
-    src_f24->x.x.x = srcPtrR_f8->x.x;
-    src_f24->x.x.y = srcPtrG_f8->x.x;
-    src_f24->x.x.z = srcPtrB_f8->x.x;
-
-    src_f24->x.x.w = srcPtrR_f8->x.y;
-    src_f24->x.y.x = srcPtrG_f8->x.y;
-    src_f24->x.y.y = srcPtrB_f8->x.y;
-
-    src_f24->x.y.z = srcPtrR_f8->x.z;
-    src_f24->x.y.w = srcPtrG_f8->x.z;
-    src_f24->y.x.x = srcPtrB_f8->x.z;
-
-    src_f24->y.x.y = srcPtrR_f8->x.w;
-    src_f24->y.x.z = srcPtrG_f8->x.w;
-    src_f24->y.x.w = srcPtrB_f8->x.w;
-
-    src_f24->y.y.x = srcPtrR_f8->y.x;
-    src_f24->y.y.y = srcPtrG_f8->y.x;
-    src_f24->y.y.z = srcPtrB_f8->y.x;
-
-    src_f24->y.y.w = srcPtrR_f8->y.y;
-    src_f24->z.x.x = srcPtrG_f8->y.y;
-    src_f24->z.x.y = srcPtrB_f8->y.y;
-
-    src_f24->z.x.z = srcPtrR_f8->y.z;
-    src_f24->z.x.w = srcPtrG_f8->y.z;
-    src_f24->z.y.x = srcPtrB_f8->y.z;
-
-    src_f24->z.y.y = srcPtrR_f8->y.w;
-    src_f24->z.y.z = srcPtrG_f8->y.w;
-    src_f24->z.y.w = srcPtrB_f8->y.w;
+    src_f24->x.x = make_float4(srcPtrR_f8->x.x, srcPtrG_f8->x.x, srcPtrB_f8->x.x, srcPtrR_f8->x.y);    // write R00G00B00R01
+    src_f24->x.y = make_float4(srcPtrG_f8->x.y, srcPtrB_f8->x.y, srcPtrR_f8->x.z, srcPtrG_f8->x.z);    // write G01B01R02G02
+    src_f24->y.x = make_float4(srcPtrB_f8->x.z, srcPtrR_f8->x.w, srcPtrG_f8->x.w, srcPtrB_f8->x.w);    // write B02R03G03B03
+    src_f24->y.y = make_float4(srcPtrR_f8->y.x, srcPtrG_f8->y.x, srcPtrB_f8->y.x, srcPtrR_f8->y.y);    // write R04G04B04R05
+    src_f24->z.x = make_float4(srcPtrG_f8->y.y, srcPtrB_f8->y.y, srcPtrR_f8->y.z, srcPtrG_f8->y.z);    // write G05B05R06G06
+    src_f24->z.y = make_float4(srcPtrB_f8->y.z, srcPtrR_f8->y.w, srcPtrG_f8->y.w, srcPtrB_f8->y.w);    // write B06R07G07B07
 }
 
 // I8 loads with layout toggle PLN3 to PKD3 (24 I8 pixels)
@@ -1090,12 +937,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pkd3(s
     srcTempPtr += increment;
     src.z = *((int2 *)(srcTempPtr));
 
-    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.x.x));
-    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.x.x), rpp_hip_unpack2(src.y.x));
-    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack3(src.y.x), rpp_hip_unpack3(src.z.x));
-    src_f24->y.y = make_float4(rpp_hip_unpack0(src.x.y), rpp_hip_unpack0(src.y.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.x.y));
-    src_f24->z.x = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.x.y), rpp_hip_unpack2(src.y.y));
-    src_f24->z.y = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack3(src.z.y));
+    src_f24->x.x = make_float4(rpp_hip_unpack0(src.x.x), rpp_hip_unpack0(src.y.x), rpp_hip_unpack0(src.z.x), rpp_hip_unpack1(src.x.x));    // write R00G00B00R01
+    src_f24->x.y = make_float4(rpp_hip_unpack1(src.y.x), rpp_hip_unpack1(src.z.x), rpp_hip_unpack2(src.x.x), rpp_hip_unpack2(src.y.x));    // write G01B01R02G02
+    src_f24->y.x = make_float4(rpp_hip_unpack2(src.z.x), rpp_hip_unpack3(src.x.x), rpp_hip_unpack3(src.y.x), rpp_hip_unpack3(src.z.x));    // write B02R03G03B03
+    src_f24->y.y = make_float4(rpp_hip_unpack0(src.x.y), rpp_hip_unpack0(src.y.y), rpp_hip_unpack0(src.z.y), rpp_hip_unpack1(src.x.y));    // write R04G04B04R05
+    src_f24->z.x = make_float4(rpp_hip_unpack1(src.y.y), rpp_hip_unpack1(src.z.y), rpp_hip_unpack2(src.x.y), rpp_hip_unpack2(src.y.y));    // write G05B05R06G06
+    src_f24->z.y = make_float4(rpp_hip_unpack2(src.z.y), rpp_hip_unpack3(src.x.y), rpp_hip_unpack3(src.y.y), rpp_hip_unpack3(src.z.y));    // write B06R07G07B07
 }
 
 // F16 loads with layout toggle PLN3 to PKD3 (24 F16 pixels)
@@ -1112,37 +959,12 @@ __device__ __forceinline__ void rpp_hip_load24_pln3_and_unpack_to_float24_pkd3(h
     srcG_h8 = (d_half8 *)srcPtrG;
     srcB_h8 = (d_half8 *)srcPtrB;
 
-    src_f24->x.x.x = __half2float(__low2half(srcR_h8->x.x));
-    src_f24->x.x.y = __half2float(__low2half(srcG_h8->x.x));
-    src_f24->x.x.z = __half2float(__low2half(srcB_h8->x.x));
-
-    src_f24->x.x.w = __half2float(__high2half(srcR_h8->x.x));
-    src_f24->x.y.x = __half2float(__high2half(srcG_h8->x.x));
-    src_f24->x.y.y = __half2float(__high2half(srcB_h8->x.x));
-
-    src_f24->x.y.z = __half2float(__low2half(srcR_h8->x.y));
-    src_f24->x.y.w = __half2float(__low2half(srcG_h8->x.y));
-    src_f24->y.x.x = __half2float(__low2half(srcB_h8->x.y));
-
-    src_f24->y.x.y = __half2float(__high2half(srcR_h8->x.y));
-    src_f24->y.x.z = __half2float(__high2half(srcG_h8->x.y));
-    src_f24->y.x.w = __half2float(__high2half(srcB_h8->x.y));
-
-    src_f24->y.y.x = __half2float(__low2half(srcR_h8->y.x));
-    src_f24->y.y.y = __half2float(__low2half(srcG_h8->y.x));
-    src_f24->y.y.z = __half2float(__low2half(srcB_h8->y.x));
-
-    src_f24->y.y.w = __half2float(__high2half(srcR_h8->y.x));
-    src_f24->z.x.x = __half2float(__high2half(srcG_h8->y.x));
-    src_f24->z.x.y = __half2float(__high2half(srcB_h8->y.x));
-
-    src_f24->z.x.z = __half2float(__low2half(srcR_h8->y.y));
-    src_f24->z.x.w = __half2float(__low2half(srcG_h8->y.y));
-    src_f24->z.y.x = __half2float(__low2half(srcB_h8->y.y));
-
-    src_f24->z.y.y = __half2float(__high2half(srcR_h8->y.y));
-    src_f24->z.y.z = __half2float(__high2half(srcG_h8->y.y));
-    src_f24->z.y.w = __half2float(__high2half(srcB_h8->y.y));
+    src_f24->x.x = make_float4(__half2float(__low2half(srcR_h8->x.x)), __half2float(__low2half(srcG_h8->x.x)), __half2float(__low2half(srcB_h8->x.x)), __half2float(__high2half(srcR_h8->x.x)));      // write R00G00B00R01
+    src_f24->x.y = make_float4(__half2float(__high2half(srcG_h8->x.x)), __half2float(__high2half(srcB_h8->x.x)), __half2float(__low2half(srcR_h8->x.y)), __half2float(__low2half(srcG_h8->x.y)));     // write G01B01R02G02
+    src_f24->y.x = make_float4(__half2float(__low2half(srcB_h8->x.y)), __half2float(__high2half(srcR_h8->x.y)), __half2float(__high2half(srcG_h8->x.y)), __half2float(__high2half(srcB_h8->x.y)));    // write B02R03G03B03
+    src_f24->y.y = make_float4(__half2float(__low2half(srcR_h8->y.x)), __half2float(__low2half(srcG_h8->y.x)), __half2float(__low2half(srcB_h8->y.x)), __half2float(__high2half(srcR_h8->y.x)));      // write R04G04B04R05
+    src_f24->z.x = make_float4(__half2float(__high2half(srcG_h8->y.x)), __half2float(__high2half(srcB_h8->y.x)), __half2float(__low2half(srcR_h8->y.y)), __half2float(__low2half(srcG_h8->y.y)));     // write G05B05R06G06
+    src_f24->z.y = make_float4(__half2float(__low2half(srcB_h8->y.y)), __half2float(__high2half(srcR_h8->y.y)), __half2float(__high2half(srcG_h8->y.y)), __half2float(__high2half(srcB_h8->y.y)));    // write B06R07G07B07
 }
 
 // -------------------- Set 5 - Stores from float --------------------
@@ -1196,12 +1018,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pkd3(uchar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack(dst_f24->x.x);
-    dst.x.y = rpp_hip_pack(dst_f24->x.y);
-    dst.y.x = rpp_hip_pack(dst_f24->y.x);
-    dst.y.y = rpp_hip_pack(dst_f24->y.y);
-    dst.z.x = rpp_hip_pack(dst_f24->z.x);
-    dst.z.y = rpp_hip_pack(dst_f24->z.y);
+    dst.x.x = rpp_hip_pack(dst_f24->x.x);    // write R00G00B00R01
+    dst.x.y = rpp_hip_pack(dst_f24->x.y);    // write G01B01R02G02
+    dst.y.x = rpp_hip_pack(dst_f24->y.x);    // write B02R03G03B03
+    dst.y.y = rpp_hip_pack(dst_f24->y.y);    // write R04G04B04R05
+    dst.z.x = rpp_hip_pack(dst_f24->z.x);    // write G05B05R06G06
+    dst.z.y = rpp_hip_pack(dst_f24->z.y);    // write B06R07G07B07
 
     *((d_uint6 *)(dstPtr)) = dst;
 }
@@ -1219,12 +1041,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pkd3(schar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack_i8(dst_f24->x.x);
-    dst.x.y = rpp_hip_pack_i8(dst_f24->x.y);
-    dst.y.x = rpp_hip_pack_i8(dst_f24->y.x);
-    dst.y.y = rpp_hip_pack_i8(dst_f24->y.y);
-    dst.z.x = rpp_hip_pack_i8(dst_f24->z.x);
-    dst.z.y = rpp_hip_pack_i8(dst_f24->z.y);
+    dst.x.x = rpp_hip_pack_i8(dst_f24->x.x);    // write R00G00B00R01
+    dst.x.y = rpp_hip_pack_i8(dst_f24->x.y);    // write G01B01R02G02
+    dst.y.x = rpp_hip_pack_i8(dst_f24->y.x);    // write B02R03G03B03
+    dst.y.y = rpp_hip_pack_i8(dst_f24->y.y);    // write R04G04B04R05
+    dst.z.x = rpp_hip_pack_i8(dst_f24->z.x);    // write G05B05R06G06
+    dst.z.y = rpp_hip_pack_i8(dst_f24->z.y);    // write B06R07G07B07
 
     *((d_uint6 *)(dstPtr)) = dst;
 }
@@ -1235,20 +1057,18 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pkd3(half 
 {
     d_half24 dst_h24;
 
-    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.y));
-    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.x.w));
-    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->x.y.y));
-    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->x.y.w));
-
-    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.y));
-    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.z, dst_f24->y.x.w));
-    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.y));
-    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->y.y.w));
-
-    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->z.x.y));
-    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.x.w));
-    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.y));
-    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->z.y.w));
+    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.y));    // write R00G00
+    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.x.w));    // write B00R01
+    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->x.y.y));    // write G01B01
+    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->x.y.w));    // write R02G02
+    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.y));    // write B02R03
+    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.z, dst_f24->y.x.w));    // write G03B03
+    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.y));    // write R04G04
+    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->y.y.w));    // write B04R05
+    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->z.x.y));    // write G05B05
+    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.x.w));    // write R06G06
+    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.y));    // write B06R07
+    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->z.y.w));    // write G07B07
 
     *((d_half24 *)(dstPtr)) = dst_h24;
 }
@@ -1259,12 +1079,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(uchar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack(dst_f24->x.x);
-    dst.x.y = rpp_hip_pack(dst_f24->x.y);
-    dst.y.x = rpp_hip_pack(dst_f24->y.x);
-    dst.y.y = rpp_hip_pack(dst_f24->y.y);
-    dst.z.x = rpp_hip_pack(dst_f24->z.x);
-    dst.z.y = rpp_hip_pack(dst_f24->z.y);
+    dst.x.x = rpp_hip_pack(dst_f24->x.x);    // write R00-R03
+    dst.x.y = rpp_hip_pack(dst_f24->x.y);    // write R04-R07
+    dst.y.x = rpp_hip_pack(dst_f24->y.x);    // write G00-G03
+    dst.y.y = rpp_hip_pack(dst_f24->y.y);    // write G04-G07
+    dst.z.x = rpp_hip_pack(dst_f24->z.x);    // write B00-B03
+    dst.z.y = rpp_hip_pack(dst_f24->z.y);    // write B04-B07
 
     *((uint2 *)(dstPtr)) = dst.x;
     dstPtr += increment;
@@ -1290,12 +1110,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(schar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack_i8(dst_f24->x.x);
-    dst.x.y = rpp_hip_pack_i8(dst_f24->x.y);
-    dst.y.x = rpp_hip_pack_i8(dst_f24->y.x);
-    dst.y.y = rpp_hip_pack_i8(dst_f24->y.y);
-    dst.z.x = rpp_hip_pack_i8(dst_f24->z.x);
-    dst.z.y = rpp_hip_pack_i8(dst_f24->z.y);
+    dst.x.x = rpp_hip_pack_i8(dst_f24->x.x);    // write R00-R03
+    dst.x.y = rpp_hip_pack_i8(dst_f24->x.y);    // write R04-R07
+    dst.y.x = rpp_hip_pack_i8(dst_f24->y.x);    // write G00-G03
+    dst.y.y = rpp_hip_pack_i8(dst_f24->y.y);    // write G04-G07
+    dst.z.x = rpp_hip_pack_i8(dst_f24->z.x);    // write B00-B03
+    dst.z.y = rpp_hip_pack_i8(dst_f24->z.y);    // write B04-B07
 
     *((uint2 *)(dstPtr)) = dst.x;
     dstPtr += increment;
@@ -1310,20 +1130,18 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(half 
 {
     d_half24 dst_h24;
 
-    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.y));
-    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.x.w));
-    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->x.y.y));
-    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->x.y.w));
-
-    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.y));
-    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.z, dst_f24->y.x.w));
-    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.y));
-    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->y.y.w));
-
-    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->z.x.y));
-    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.x.w));
-    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.y));
-    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->z.y.w));
+    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.y));    // write R00R01
+    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.x.w));    // write R02R03
+    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->x.y.y));    // write R04R05
+    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->x.y.w));    // write R06R07
+    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.y));    // write G00G01
+    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.z, dst_f24->y.x.w));    // write G02G03
+    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.y));    // write G04G05
+    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->y.y.w));    // write G06G07
+    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->z.x.y));    // write B00B01
+    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.x.w));    // write B02B03
+    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.y));    // write B04B05
+    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->z.y.w));    // write B06B07
 
     *((d_half8 *)(dstPtr)) = dst_h24.x;
     dstPtr += increment;
@@ -1340,12 +1158,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(uchar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack(make_float4(dst_f24->x.x.x, dst_f24->y.x.x, dst_f24->z.x.x, dst_f24->x.x.y));
-    dst.x.y = rpp_hip_pack(make_float4(dst_f24->y.x.y, dst_f24->z.x.y, dst_f24->x.x.z, dst_f24->y.x.z));
-    dst.y.x = rpp_hip_pack(make_float4(dst_f24->z.x.z, dst_f24->x.x.w, dst_f24->y.x.w, dst_f24->z.x.w));
-    dst.y.y = rpp_hip_pack(make_float4(dst_f24->x.y.x, dst_f24->y.y.x, dst_f24->z.y.x, dst_f24->x.y.y));
-    dst.z.x = rpp_hip_pack(make_float4(dst_f24->y.y.y, dst_f24->z.y.y, dst_f24->x.y.z, dst_f24->y.y.z));
-    dst.z.y = rpp_hip_pack(make_float4(dst_f24->z.y.z, dst_f24->x.y.w, dst_f24->y.y.w, dst_f24->z.y.w));
+    dst.x.x = rpp_hip_pack(make_float4(dst_f24->x.x.x, dst_f24->y.x.x, dst_f24->z.x.x, dst_f24->x.x.y));    // write R00G00B00R01
+    dst.x.y = rpp_hip_pack(make_float4(dst_f24->y.x.y, dst_f24->z.x.y, dst_f24->x.x.z, dst_f24->y.x.z));    // write G01B01R02G02
+    dst.y.x = rpp_hip_pack(make_float4(dst_f24->z.x.z, dst_f24->x.x.w, dst_f24->y.x.w, dst_f24->z.x.w));    // write B02R03G03B03
+    dst.y.y = rpp_hip_pack(make_float4(dst_f24->x.y.x, dst_f24->y.y.x, dst_f24->z.y.x, dst_f24->x.y.y));    // write R04G04B04R05
+    dst.z.x = rpp_hip_pack(make_float4(dst_f24->y.y.y, dst_f24->z.y.y, dst_f24->x.y.z, dst_f24->y.y.z));    // write G05B05R06G06
+    dst.z.y = rpp_hip_pack(make_float4(dst_f24->z.y.z, dst_f24->x.y.w, dst_f24->y.y.w, dst_f24->z.y.w));    // write B06R07G07B07
 
     *((d_uint6 *)(dstPtr)) = dst;
 }
@@ -1356,37 +1174,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(float
 {
     d_float24 dstPtr_f24;
 
-    dstPtr_f24.x.x.x = dst_f24->x.x.x;
-    dstPtr_f24.x.x.y = dst_f24->y.x.x;
-    dstPtr_f24.x.x.z = dst_f24->z.x.x;
-
-    dstPtr_f24.x.x.w = dst_f24->x.x.y;
-    dstPtr_f24.x.y.x = dst_f24->y.x.y;
-    dstPtr_f24.x.y.y = dst_f24->z.x.y;
-
-    dstPtr_f24.x.y.z = dst_f24->x.x.z;
-    dstPtr_f24.x.y.w = dst_f24->y.x.z;
-    dstPtr_f24.y.x.x = dst_f24->z.x.z;
-
-    dstPtr_f24.y.x.y = dst_f24->x.x.w;
-    dstPtr_f24.y.x.z = dst_f24->y.x.w;
-    dstPtr_f24.y.x.w = dst_f24->z.x.w;
-
-    dstPtr_f24.y.y.x = dst_f24->x.y.x;
-    dstPtr_f24.y.y.y = dst_f24->y.y.x;
-    dstPtr_f24.y.y.z = dst_f24->z.y.x;
-
-    dstPtr_f24.y.y.w = dst_f24->x.y.y;
-    dstPtr_f24.z.x.x = dst_f24->y.y.y;
-    dstPtr_f24.z.x.y = dst_f24->z.y.y;
-
-    dstPtr_f24.z.x.z = dst_f24->x.y.z;
-    dstPtr_f24.z.x.w = dst_f24->y.y.z;
-    dstPtr_f24.z.y.x = dst_f24->z.y.z;
-
-    dstPtr_f24.z.y.y = dst_f24->x.y.w;
-    dstPtr_f24.z.y.z = dst_f24->y.y.w;
-    dstPtr_f24.z.y.w = dst_f24->z.y.w;
+    dstPtr_f24.x.x = make_float4(dst_f24->x.x.x, dst_f24->y.x.x, dst_f24->z.x.x, dst_f24->x.x.y);    // write R00G00B00R01
+    dstPtr_f24.x.y = make_float4(dst_f24->y.x.y, dst_f24->z.x.y, dst_f24->x.x.z, dst_f24->y.x.z);    // write G01B01R02G02
+    dstPtr_f24.y.x = make_float4(dst_f24->z.x.z, dst_f24->x.x.w, dst_f24->y.x.w, dst_f24->z.x.w);    // write B02R03G03B03
+    dstPtr_f24.y.y = make_float4(dst_f24->x.y.x, dst_f24->y.y.x, dst_f24->z.y.x, dst_f24->x.y.y);    // write R04G04B04R05
+    dstPtr_f24.z.x = make_float4(dst_f24->y.y.y, dst_f24->z.y.y, dst_f24->x.y.z, dst_f24->y.y.z);    // write G05B05R06G06
+    dstPtr_f24.z.y = make_float4(dst_f24->z.y.z, dst_f24->x.y.w, dst_f24->y.y.w, dst_f24->z.y.w);    // write B06R07G07B07
 
     *((d_float24 *)(dstPtr)) = dstPtr_f24;
 }
@@ -1397,12 +1190,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(schar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.x, dst_f24->y.x.x, dst_f24->z.x.x, dst_f24->x.x.y));
-    dst.x.y = rpp_hip_pack_i8(make_float4(dst_f24->y.x.y, dst_f24->z.x.y, dst_f24->x.x.z, dst_f24->y.x.z));
-    dst.y.x = rpp_hip_pack_i8(make_float4(dst_f24->z.x.z, dst_f24->x.x.w, dst_f24->y.x.w, dst_f24->z.x.w));
-    dst.y.y = rpp_hip_pack_i8(make_float4(dst_f24->x.y.x, dst_f24->y.y.x, dst_f24->z.y.x, dst_f24->x.y.y));
-    dst.z.x = rpp_hip_pack_i8(make_float4(dst_f24->y.y.y, dst_f24->z.y.y, dst_f24->x.y.z, dst_f24->y.y.z));
-    dst.z.y = rpp_hip_pack_i8(make_float4(dst_f24->z.y.z, dst_f24->x.y.w, dst_f24->y.y.w, dst_f24->z.y.w));
+    dst.x.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.x, dst_f24->y.x.x, dst_f24->z.x.x, dst_f24->x.x.y));    // write R00G00B00R01
+    dst.x.y = rpp_hip_pack_i8(make_float4(dst_f24->y.x.y, dst_f24->z.x.y, dst_f24->x.x.z, dst_f24->y.x.z));    // write G01B01R02G02
+    dst.y.x = rpp_hip_pack_i8(make_float4(dst_f24->z.x.z, dst_f24->x.x.w, dst_f24->y.x.w, dst_f24->z.x.w));    // write B02R03G03B03
+    dst.y.y = rpp_hip_pack_i8(make_float4(dst_f24->x.y.x, dst_f24->y.y.x, dst_f24->z.y.x, dst_f24->x.y.y));    // write R04G04B04R05
+    dst.z.x = rpp_hip_pack_i8(make_float4(dst_f24->y.y.y, dst_f24->z.y.y, dst_f24->x.y.z, dst_f24->y.y.z));    // write G05B05R06G06
+    dst.z.y = rpp_hip_pack_i8(make_float4(dst_f24->z.y.z, dst_f24->x.y.w, dst_f24->y.y.w, dst_f24->z.y.w));    // write B06R07G07B07
 
     *((d_uint6 *)(dstPtr)) = dst;
 }
@@ -1413,20 +1206,18 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(half 
 {
     d_half24 dst_h24;
 
-    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->y.x.x));
-    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->x.x.y));
-    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->y.x.y, dst_f24->z.x.y));
-    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->y.x.z));
-
-    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->x.x.w));
-    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.w, dst_f24->z.x.w));
-    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->y.y.x));
-    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->x.y.y));
-
-    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->y.y.y, dst_f24->z.y.y));
-    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->y.y.z));
-    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->x.y.w));
-    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->y.y.w, dst_f24->z.y.w));
+    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->y.x.x));    // write R00G00
+    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->z.x.x, dst_f24->x.x.y));    // write B00R01
+    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->y.x.y, dst_f24->z.x.y));    // write G01B01
+    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->y.x.z));    // write R02G02
+    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->x.x.w));    // write B02R03
+    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->y.x.w, dst_f24->z.x.w));    // write G03B03
+    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->x.y.x, dst_f24->y.y.x));    // write R04G04
+    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->x.y.y));    // write B04R05
+    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->y.y.y, dst_f24->z.y.y));    // write G05B05
+    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->y.y.z));    // write R06G06
+    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->x.y.w));    // write B06R07
+    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->y.y.w, dst_f24->z.y.w));    // write G07B07
 
     *((d_half24 *)(dstPtr)) = dst_h24;
 }
@@ -1437,12 +1228,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(uchar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack(make_float4(dst_f24->x.x.x, dst_f24->x.x.w, dst_f24->x.y.z, dst_f24->y.x.y));
-    dst.x.y = rpp_hip_pack(make_float4(dst_f24->y.y.x, dst_f24->y.y.w, dst_f24->z.x.z, dst_f24->z.y.y));
-    dst.y.x = rpp_hip_pack(make_float4(dst_f24->x.x.y, dst_f24->x.y.x, dst_f24->x.y.w, dst_f24->y.x.z));
-    dst.y.y = rpp_hip_pack(make_float4(dst_f24->y.y.y, dst_f24->z.x.x, dst_f24->z.x.w, dst_f24->z.y.z));
-    dst.z.x = rpp_hip_pack(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));
-    dst.z.y = rpp_hip_pack(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));
+    dst.x.x = rpp_hip_pack(make_float4(dst_f24->x.x.x, dst_f24->x.x.w, dst_f24->x.y.z, dst_f24->y.x.y));    // write R00-R03
+    dst.x.y = rpp_hip_pack(make_float4(dst_f24->y.y.x, dst_f24->y.y.w, dst_f24->z.x.z, dst_f24->z.y.y));    // write R04-R07
+    dst.y.x = rpp_hip_pack(make_float4(dst_f24->x.x.y, dst_f24->x.y.x, dst_f24->x.y.w, dst_f24->y.x.z));    // write G00-G03
+    dst.y.y = rpp_hip_pack(make_float4(dst_f24->y.y.y, dst_f24->z.x.x, dst_f24->z.x.w, dst_f24->z.y.z));    // write G04-G07
+    dst.z.x = rpp_hip_pack(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));    // write B00-B03
+    dst.z.y = rpp_hip_pack(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));    // write B04-B07
 
     *((uint2 *)(dstPtr)) = dst.x;
     dstPtr += increment;
@@ -1457,32 +1248,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(float
 {
     d_float24 dstPtr_f24;
 
-    dstPtr_f24.x.x.x = dst_f24->x.x.x;
-    dstPtr_f24.x.x.y = dst_f24->x.x.w;
-    dstPtr_f24.x.x.z = dst_f24->x.y.z;
-    dstPtr_f24.x.x.w = dst_f24->y.x.y;
-    dstPtr_f24.x.y.x = dst_f24->y.y.x;
-    dstPtr_f24.x.y.y = dst_f24->y.y.w;
-    dstPtr_f24.x.y.z = dst_f24->z.x.z;
-    dstPtr_f24.x.y.w = dst_f24->z.y.y;
-
-    dstPtr_f24.y.x.x = dst_f24->x.x.y;
-    dstPtr_f24.y.x.y = dst_f24->x.y.x;
-    dstPtr_f24.y.x.z = dst_f24->x.y.w;
-    dstPtr_f24.y.x.w = dst_f24->y.x.z;
-    dstPtr_f24.y.y.x = dst_f24->y.y.y;
-    dstPtr_f24.y.y.y = dst_f24->z.x.x;
-    dstPtr_f24.y.y.z = dst_f24->z.x.w;
-    dstPtr_f24.y.y.w = dst_f24->z.y.z;
-
-    dstPtr_f24.z.x.x = dst_f24->x.x.z;
-    dstPtr_f24.z.x.y = dst_f24->x.y.y;
-    dstPtr_f24.z.x.z = dst_f24->y.x.x;
-    dstPtr_f24.z.x.w = dst_f24->y.x.w;
-    dstPtr_f24.z.y.x = dst_f24->y.y.z;
-    dstPtr_f24.z.y.y = dst_f24->z.x.y;
-    dstPtr_f24.z.y.z = dst_f24->z.y.x;
-    dstPtr_f24.z.y.w = dst_f24->z.y.w;
+    dstPtr_f24.x.x = make_float4(dst_f24->x.x.x, dst_f24->x.x.w, dst_f24->x.y.z, dst_f24->y.x.y);    // write R00-R03
+    dstPtr_f24.x.y = make_float4(dst_f24->y.y.x, dst_f24->y.y.w, dst_f24->z.x.z, dst_f24->z.y.y);    // write R04-R07
+    dstPtr_f24.y.x = make_float4(dst_f24->x.x.y, dst_f24->x.y.x, dst_f24->x.y.w, dst_f24->y.x.z);    // write G00-G03
+    dstPtr_f24.y.y = make_float4(dst_f24->y.y.y, dst_f24->z.x.x, dst_f24->z.x.w, dst_f24->z.y.z);    // write G04-G07
+    dstPtr_f24.z.x = make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w);    // write B00-B03
+    dstPtr_f24.z.y = make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w);    // write B04-B07
 
     *(d_float8 *)dstPtr = dstPtr_f24.x;
     dstPtr += increment;
@@ -1497,12 +1268,12 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(schar
 {
     d_uint6 dst;
 
-    dst.x.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.x, dst_f24->x.x.w, dst_f24->x.y.z, dst_f24->y.x.y));
-    dst.x.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.x, dst_f24->y.y.w, dst_f24->z.x.z, dst_f24->z.y.y));
-    dst.y.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.y, dst_f24->x.y.x, dst_f24->x.y.w, dst_f24->y.x.z));
-    dst.y.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.y, dst_f24->z.x.x, dst_f24->z.x.w, dst_f24->z.y.z));
-    dst.z.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));
-    dst.z.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));
+    dst.x.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.x, dst_f24->x.x.w, dst_f24->x.y.z, dst_f24->y.x.y));    // write R00-R03
+    dst.x.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.x, dst_f24->y.y.w, dst_f24->z.x.z, dst_f24->z.y.y));    // write R04-R07
+    dst.y.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.y, dst_f24->x.y.x, dst_f24->x.y.w, dst_f24->y.x.z));    // write G00-G03
+    dst.y.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.y, dst_f24->z.x.x, dst_f24->z.x.w, dst_f24->z.y.z));    // write G04-G07
+    dst.z.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));    // write B00-B03
+    dst.z.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));    // write B04-B07
 
     *((uint2 *)(dstPtr)) = dst.x;
     dstPtr += increment;
@@ -1517,20 +1288,18 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(half 
 {
     d_half24 dst_h24;
 
-    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.w));
-    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->y.x.y));
-    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.w));
-    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.y.y));
-
-    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->x.x.y, dst_f24->x.y.x));
-    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->x.y.w, dst_f24->y.x.z));
-    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.y, dst_f24->z.x.x));
-    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->z.x.w, dst_f24->z.y.z));
-
-    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.y.y));
-    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.w));
-    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->z.x.y));
-    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.w));
+    dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.w));    // write R00R01
+    dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.y.z, dst_f24->y.x.y));    // write R02R03
+    dst_h24.x.y.x = __float22half2_rn(make_float2(dst_f24->y.y.x, dst_f24->y.y.w));    // write R04R05
+    dst_h24.x.y.y = __float22half2_rn(make_float2(dst_f24->z.x.z, dst_f24->z.y.y));    // write R06R07
+    dst_h24.y.x.x = __float22half2_rn(make_float2(dst_f24->x.x.y, dst_f24->x.y.x));    // write G00G01
+    dst_h24.y.x.y = __float22half2_rn(make_float2(dst_f24->x.y.w, dst_f24->y.x.z));    // write G02G03
+    dst_h24.y.y.x = __float22half2_rn(make_float2(dst_f24->y.y.y, dst_f24->z.x.x));    // write G04G05
+    dst_h24.y.y.y = __float22half2_rn(make_float2(dst_f24->z.x.w, dst_f24->z.y.z));    // write G06G07
+    dst_h24.z.x.x = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.y.y));    // write B00B01
+    dst_h24.z.x.y = __float22half2_rn(make_float2(dst_f24->y.x.x, dst_f24->y.x.w));    // write B02B03
+    dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->z.x.y));    // write B04B05
+    dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.w));    // write B06B07
 
     *((d_half8 *)(dstPtr)) = dst_h24.x;
     dstPtr += increment;
@@ -1597,32 +1366,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_to_uchar8_pln3(uchar *srcPtr
     src_c2_uchar8 = (d_uchar8 *)srcPtrs_uchar8[1];
     src_c3_uchar8 = (d_uchar8 *)srcPtrs_uchar8[2];
 
-    src_c1_uchar8->x.x = srcPtr_uchar24->x.x.x;
-    src_c1_uchar8->x.y = srcPtr_uchar24->x.x.w;
-    src_c1_uchar8->x.z = srcPtr_uchar24->x.y.z;
-    src_c1_uchar8->x.w = srcPtr_uchar24->y.x.y;
-    src_c1_uchar8->y.x = srcPtr_uchar24->y.y.x;
-    src_c1_uchar8->y.y = srcPtr_uchar24->y.y.w;
-    src_c1_uchar8->y.z = srcPtr_uchar24->z.x.z;
-    src_c1_uchar8->y.w = srcPtr_uchar24->z.y.y;
-
-    src_c2_uchar8->x.x = srcPtr_uchar24->x.x.y;
-    src_c2_uchar8->x.y = srcPtr_uchar24->x.y.x;
-    src_c2_uchar8->x.z = srcPtr_uchar24->x.y.w;
-    src_c2_uchar8->x.w = srcPtr_uchar24->y.x.z;
-    src_c2_uchar8->y.x = srcPtr_uchar24->y.y.y;
-    src_c2_uchar8->y.y = srcPtr_uchar24->z.x.x;
-    src_c2_uchar8->y.z = srcPtr_uchar24->z.x.w;
-    src_c2_uchar8->y.w = srcPtr_uchar24->z.y.z;
-
-    src_c3_uchar8->x.x = srcPtr_uchar24->x.x.z;
-    src_c3_uchar8->x.y = srcPtr_uchar24->x.y.y;
-    src_c3_uchar8->x.z = srcPtr_uchar24->y.x.x;
-    src_c3_uchar8->x.w = srcPtr_uchar24->y.x.w;
-    src_c3_uchar8->y.x = srcPtr_uchar24->y.y.z;
-    src_c3_uchar8->y.y = srcPtr_uchar24->z.x.y;
-    src_c3_uchar8->y.z = srcPtr_uchar24->z.y.x;
-    src_c3_uchar8->y.w = srcPtr_uchar24->z.y.w;
+    src_c1_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.x, srcPtr_uchar24->x.x.w, srcPtr_uchar24->x.y.z, srcPtr_uchar24->y.x.y);    // write R00-R03
+    src_c1_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.x, srcPtr_uchar24->y.y.w, srcPtr_uchar24->z.x.z, srcPtr_uchar24->z.y.y);    // write R04-R07
+    src_c2_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.y, srcPtr_uchar24->x.y.x, srcPtr_uchar24->x.y.w, srcPtr_uchar24->y.x.z);    // write G00-G03
+    src_c2_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.y, srcPtr_uchar24->z.x.x, srcPtr_uchar24->z.x.w, srcPtr_uchar24->z.y.z);    // write G04-G07
+    src_c3_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.z, srcPtr_uchar24->x.y.y, srcPtr_uchar24->y.x.x, srcPtr_uchar24->y.x.w);    // write B00-B03
+    src_c3_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.z, srcPtr_uchar24->z.x.y, srcPtr_uchar24->z.y.x, srcPtr_uchar24->z.y.w);    // write B04-B07
 }
 
 // F32 loads with layout toggle PKD3 to PLN3 (24 F32 pixels)
@@ -1633,12 +1382,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_to_uchar8_pln3(float *srcPtr
     srcPtr_f24 = (d_float24 *)srcPtr;
 
     d_uint6 src_uchar24;
-    src_uchar24.x.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->x.x * (float4) 255.0));
-    src_uchar24.x.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->x.y * (float4) 255.0));
-    src_uchar24.y.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->y.x * (float4) 255.0));
-    src_uchar24.y.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->y.y * (float4) 255.0));
-    src_uchar24.z.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->z.x * (float4) 255.0));
-    src_uchar24.z.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->z.y * (float4) 255.0));
+    src_uchar24.x.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->x.x * (float4) 255.0));    // write R00G00B00R01
+    src_uchar24.x.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->x.y * (float4) 255.0));    // write G01B01R02G02
+    src_uchar24.y.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->y.x * (float4) 255.0));    // write B02R03G03B03
+    src_uchar24.y.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->y.y * (float4) 255.0));    // write R04G04B04R05
+    src_uchar24.z.x = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->z.x * (float4) 255.0));    // write G05B05R06G06
+    src_uchar24.z.y = rpp_hip_pack(rpp_hip_pixel_check_0to255(srcPtr_f24->z.y * (float4) 255.0));    // write B06R07G07B07
 
     d_uchar8 *src_c1_uchar8, *src_c2_uchar8, *src_c3_uchar8;
     src_c1_uchar8 = (d_uchar8 *)srcPtrs_uchar8[0];
@@ -1648,32 +1397,12 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_to_uchar8_pln3(float *srcPtr
     d_uchar24 *srcPtr_uchar24;
     srcPtr_uchar24 = (d_uchar24 *)&src_uchar24;
 
-    src_c1_uchar8->x.x = srcPtr_uchar24->x.x.x;
-    src_c1_uchar8->x.y = srcPtr_uchar24->x.x.w;
-    src_c1_uchar8->x.z = srcPtr_uchar24->x.y.z;
-    src_c1_uchar8->x.w = srcPtr_uchar24->y.x.y;
-    src_c1_uchar8->y.x = srcPtr_uchar24->y.y.x;
-    src_c1_uchar8->y.y = srcPtr_uchar24->y.y.w;
-    src_c1_uchar8->y.z = srcPtr_uchar24->z.x.z;
-    src_c1_uchar8->y.w = srcPtr_uchar24->z.y.y;
-
-    src_c2_uchar8->x.x = srcPtr_uchar24->x.x.y;
-    src_c2_uchar8->x.y = srcPtr_uchar24->x.y.x;
-    src_c2_uchar8->x.z = srcPtr_uchar24->x.y.w;
-    src_c2_uchar8->x.w = srcPtr_uchar24->y.x.z;
-    src_c2_uchar8->y.x = srcPtr_uchar24->y.y.y;
-    src_c2_uchar8->y.y = srcPtr_uchar24->z.x.x;
-    src_c2_uchar8->y.z = srcPtr_uchar24->z.x.w;
-    src_c2_uchar8->y.w = srcPtr_uchar24->z.y.z;
-
-    src_c3_uchar8->x.x = srcPtr_uchar24->x.x.z;
-    src_c3_uchar8->x.y = srcPtr_uchar24->x.y.y;
-    src_c3_uchar8->x.z = srcPtr_uchar24->y.x.x;
-    src_c3_uchar8->x.w = srcPtr_uchar24->y.x.w;
-    src_c3_uchar8->y.x = srcPtr_uchar24->y.y.z;
-    src_c3_uchar8->y.y = srcPtr_uchar24->z.x.y;
-    src_c3_uchar8->y.z = srcPtr_uchar24->z.y.x;
-    src_c3_uchar8->y.w = srcPtr_uchar24->z.y.w;
+    src_c1_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.x, srcPtr_uchar24->x.x.w, srcPtr_uchar24->x.y.z, srcPtr_uchar24->y.x.y);    // write R00-R03
+    src_c1_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.x, srcPtr_uchar24->y.y.w, srcPtr_uchar24->z.x.z, srcPtr_uchar24->z.y.y);    // write R04-R07
+    src_c2_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.y, srcPtr_uchar24->x.y.x, srcPtr_uchar24->x.y.w, srcPtr_uchar24->y.x.z);    // write G00-G03
+    src_c2_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.y, srcPtr_uchar24->z.x.x, srcPtr_uchar24->z.x.w, srcPtr_uchar24->z.y.z);    // write G04-G07
+    src_c3_uchar8->x = make_uchar4(srcPtr_uchar24->x.x.z, srcPtr_uchar24->x.y.y, srcPtr_uchar24->y.x.x, srcPtr_uchar24->y.x.w);    // write B00-B03
+    src_c3_uchar8->y = make_uchar4(srcPtr_uchar24->y.y.z, srcPtr_uchar24->z.x.y, srcPtr_uchar24->z.y.x, srcPtr_uchar24->z.y.w);    // write B04-B07
 }
 
 // F16 loads with layout toggle PKD3 to PLN3 (24 F16 pixels)
@@ -1688,22 +1417,22 @@ __device__ __forceinline__ void rpp_hip_load24_pkd3_to_uchar8_pln3(half *srcPtr,
 
     src1_f2 = __half22float2(srcPtr_h24->x.x.x);
     src2_f2 = __half22float2(srcPtr_h24->x.x.y);
-    src_f24.x.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.x.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write R00-R03
     src1_f2 = __half22float2(srcPtr_h24->x.y.x);
     src2_f2 = __half22float2(srcPtr_h24->x.y.y);
-    src_f24.x.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.x.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write R04-R07
     src1_f2 = __half22float2(srcPtr_h24->y.x.x);
     src2_f2 = __half22float2(srcPtr_h24->y.x.y);
-    src_f24.y.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.y.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write G00-G03
     src1_f2 = __half22float2(srcPtr_h24->y.y.x);
     src2_f2 = __half22float2(srcPtr_h24->y.y.y);
-    src_f24.y.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.y.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write G04-G07
     src1_f2 = __half22float2(srcPtr_h24->z.x.x);
     src2_f2 = __half22float2(srcPtr_h24->z.x.y);
-    src_f24.z.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.z.x = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write B00-B03
     src1_f2 = __half22float2(srcPtr_h24->z.y.x);
     src2_f2 = __half22float2(srcPtr_h24->z.y.y);
-    src_f24.z.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);
+    src_f24.z.y = make_float4(src1_f2.x, src1_f2.y, src2_f2.x, src2_f2.y);    // write B04-B07
 
     rpp_hip_load24_pkd3_to_uchar8_pln3((float *)&src_f24, srcPtrs_uchar8);
 }

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1392,7 +1392,7 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(float
     dstPtr_f24.z.y.z = dst_f24->y.y.w;
     dstPtr_f24.z.y.w = dst_f24->z.y.w;
 
-    *(d_float24 *)&dstPtr[dstIdx] = dstPtr_f24;
+    *((d_float24 *)(dstPtr)) = dstPtr_f24;
 }
 
 // I8 stores with layout toggle PLN3 to PKD3 (24 I8 pixels)
@@ -1437,7 +1437,7 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(half 
 
 // U8 stores with layout toggle PKD3 to PLN3 (24 U8 pixels)
 
-__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(uchar *dstPtr, uint dstIdx, uint increment, d_float24 *dst_f24)
+__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(uchar *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_uint6 dst;
 
@@ -1448,16 +1448,16 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(uchar
     dst.z.x = rpp_hip_pack(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));
     dst.z.y = rpp_hip_pack(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));
 
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.x;
-    dstIdx += increment;
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.y;
-    dstIdx += increment;
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.z;
+    *((uint2 *)(dstPtr)) = dst.x;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.y;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.z;
 }
 
 // F32 stores with layout toggle PKD3 to PLN3 (24 F32 pixels)
 
-__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(float *dstPtr, uint dstIdx, uint increment, d_float24 *dst_f24)
+__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(float *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_float24 dstPtr_f24;
 
@@ -1488,16 +1488,16 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(float
     dstPtr_f24.z.y.z = dst_f24->z.y.x;
     dstPtr_f24.z.y.w = dst_f24->z.y.w;
 
-    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.x;
-    dstIdx += increment;
-    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.y;
-    dstIdx += increment;
-    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.z;
+    *(d_float8 *)dstPtr = dstPtr_f24.x;
+    dstPtr += increment;
+    *(d_float8 *)dstPtr = dstPtr_f24.y;
+    dstPtr += increment;
+    *(d_float8 *)dstPtr = dstPtr_f24.z;
 }
 
 // I8 stores with layout toggle PKD3 to PLN3 (24 I8 pixels)
 
-__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(schar *dstPtr, uint dstIdx, uint increment, d_float24 *dst_f24)
+__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(schar *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_uint6 dst;
 
@@ -1508,16 +1508,16 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(schar
     dst.z.x = rpp_hip_pack_i8(make_float4(dst_f24->x.x.z, dst_f24->x.y.y, dst_f24->y.x.x, dst_f24->y.x.w));
     dst.z.y = rpp_hip_pack_i8(make_float4(dst_f24->y.y.z, dst_f24->z.x.y, dst_f24->z.y.x, dst_f24->z.y.w));
 
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.x;
-    dstIdx += increment;
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.y;
-    dstIdx += increment;
-    *((uint2 *)(&dstPtr[dstIdx])) = dst.z;
+    *((uint2 *)(dstPtr)) = dst.x;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.y;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.z;
 }
 
 // F16 stores with layout toggle PKD3 to PLN3 (24 F16 pixels)
 
-__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(half *dstPtr, uint dstIdx, uint increment, d_float24 *dst_f24)
+__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(half *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_half24 dst_h24;
 
@@ -1536,11 +1536,11 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(half 
     dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->y.y.z, dst_f24->z.x.y));
     dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.w));
 
-    *((d_half8 *)(&dstPtr[dstIdx])) = dst_h24.x;
-    dstIdx += increment;
-    *((d_half8 *)(&dstPtr[dstIdx])) = dst_h24.y;
-    dstIdx += increment;
-    *((d_half8 *)(&dstPtr[dstIdx])) = dst_h24.z;
+    *((d_half8 *)(dstPtr)) = dst_h24.x;
+    dstPtr += increment;
+    *((d_half8 *)(dstPtr)) = dst_h24.y;
+    dstPtr += increment;
+    *((d_half8 *)(dstPtr)) = dst_h24.z;
 }
 
 // -------------------- Set 6 - Loads to uchar --------------------

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1258,7 +1258,6 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pkd3(half 
 __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(uchar *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_uint6 dst;
-    uchar *dstPtrTemp = dstPtr;
 
     dst.x.x = rpp_hip_pack(dst_f24->x.x);
     dst.x.y = rpp_hip_pack(dst_f24->x.y);
@@ -1267,23 +1266,22 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(uchar
     dst.z.x = rpp_hip_pack(dst_f24->z.x);
     dst.z.y = rpp_hip_pack(dst_f24->z.y);
 
-    *((uint2 *)(dstPtrTemp)) = dst.x;
-    dstPtrTemp += increment;
-    *((uint2 *)(dstPtrTemp)) = dst.y;
-    dstPtrTemp += increment;
-    *((uint2 *)(dstPtrTemp)) = dst.z;
+    *((uint2 *)(dstPtr)) = dst.x;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.y;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.z;
 }
 
 // F32 stores without layout toggle PLN3 to PLN3 (24 F32 pixels)
 
 __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(float *dstPtr, uint increment, d_float24 *dst_f24)
 {
-    float *dstPtrTemp = dstPtr;
-    *((d_float8 *)(dstPtrTemp)) = dst_f24->x;
-    dstPtrTemp += increment;
-    *((d_float8 *)(dstPtrTemp)) = dst_f24->y;
-    dstPtrTemp += increment;
-    *((d_float8 *)(dstPtrTemp)) = dst_f24->z;
+    *((d_float8 *)(dstPtr)) = dst_f24->x;
+    dstPtr += increment;
+    *((d_float8 *)(dstPtr)) = dst_f24->y;
+    dstPtr += increment;
+    *((d_float8 *)(dstPtr)) = dst_f24->z;
 }
 
 // I8 stores without layout toggle PLN3 to PLN3 (24 I8 pixels)
@@ -1291,7 +1289,6 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(float
 __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(schar *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_uint6 dst;
-    schar *dstPtrTemp = dstPtr;
 
     dst.x.x = rpp_hip_pack_i8(dst_f24->x.x);
     dst.x.y = rpp_hip_pack_i8(dst_f24->x.y);
@@ -1300,11 +1297,11 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(schar
     dst.z.x = rpp_hip_pack_i8(dst_f24->z.x);
     dst.z.y = rpp_hip_pack_i8(dst_f24->z.y);
 
-    *((uint2 *)(dstPtrTemp)) = dst.x;
-    dstPtrTemp += increment;
-    *((uint2 *)(dstPtrTemp)) = dst.y;
-    dstPtrTemp += increment;
-    *((uint2 *)(dstPtrTemp)) = dst.z;
+    *((uint2 *)(dstPtr)) = dst.x;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.y;
+    dstPtr += increment;
+    *((uint2 *)(dstPtr)) = dst.z;
 }
 
 // F16 stores without layout toggle PLN3 to PLN3 (24 F16 pixels)
@@ -1312,7 +1309,6 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(schar
 __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(half *dstPtr, uint increment, d_float24 *dst_f24)
 {
     d_half24 dst_h24;
-    half *dstPtrTemp = dstPtr;
 
     dst_h24.x.x.x = __float22half2_rn(make_float2(dst_f24->x.x.x, dst_f24->x.x.y));
     dst_h24.x.x.y = __float22half2_rn(make_float2(dst_f24->x.x.z, dst_f24->x.x.w));
@@ -1329,11 +1325,11 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pln3(half 
     dst_h24.z.y.x = __float22half2_rn(make_float2(dst_f24->z.y.x, dst_f24->z.y.y));
     dst_h24.z.y.y = __float22half2_rn(make_float2(dst_f24->z.y.z, dst_f24->z.y.w));
 
-    *((d_half8 *)(dstPtrTemp)) = dst_h24.x;
-    dstPtrTemp += increment;
-    *((d_half8 *)(dstPtrTemp)) = dst_h24.y;
-    dstPtrTemp += increment;
-    *((d_half8 *)(dstPtrTemp)) = dst_h24.z;
+    *((d_half8 *)(dstPtr)) = dst_h24.x;
+    dstPtr += increment;
+    *((d_half8 *)(dstPtr)) = dst_h24.y;
+    dstPtr += increment;
+    *((d_half8 *)(dstPtr)) = dst_h24.z;
 }
 
 // WITH LAYOUT TOGGLE

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -13,8 +13,9 @@ typedef halfhpp Rpp16f;
 // float
 typedef struct d_float6
 {
-    float3 x;
-    float3 y;
+    float2 x;
+    float2 y;
+    float2 z;
 } d_float6;
 typedef struct d_float8
 {
@@ -38,6 +39,11 @@ typedef struct d_float24
     d_float8 y;
     d_float8 z;
 } d_float24;
+typedef struct d_float6_as_float3s
+{
+    float3 x;
+    float3 y;
+} d_float6_as_float3s;
 typedef struct d_float12_as_float3s
 {
     float3 x;
@@ -86,6 +92,12 @@ typedef struct d_half4
     half2 x;
     half2 y;
 } d_half4;
+typedef struct d_half6
+{
+    half2 x;
+    half2 y;
+    half2 z;
+} d_half6;
 typedef struct d_half8
 {
     d_half4 x;
@@ -1694,9 +1706,9 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(uchar *s
 
 __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(float *srcPtr, uint srcStrideH, float2 *locSrcFloor, d_float12 *srcNeighborhood_f12)
 {
-    d_float6 src_f6;
+    d_float6_as_float3s src_f6;
     int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x * 3;
-    src_f6 = *(d_float6 *)&srcPtr[srcIdx];
+    src_f6 = *(d_float6_as_float3s *)&srcPtr[srcIdx];
     srcNeighborhood_f12->x.x = src_f6.x.x;
     srcNeighborhood_f12->x.y = src_f6.y.x;
     srcNeighborhood_f12->y.x = src_f6.x.y;
@@ -1704,7 +1716,7 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(float *s
     srcNeighborhood_f12->z.x = src_f6.x.z;
     srcNeighborhood_f12->z.y = src_f6.y.z;
     srcIdx += srcStrideH;
-    src_f6 = *(d_float6 *)&srcPtr[srcIdx];
+    src_f6 = *(d_float6_as_float3s *)&srcPtr[srcIdx];
     srcNeighborhood_f12->x.z = src_f6.x.x;
     srcNeighborhood_f12->x.w = src_f6.y.x;
     srcNeighborhood_f12->y.z = src_f6.x.y;
@@ -1740,23 +1752,31 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(schar *s
 
 __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(half *srcPtr, uint srcStrideH, float2 *locSrcFloor, d_float12 *srcNeighborhood_f12)
 {
-    // d_float6 src_f6;
-    // int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x * 3;
-    // src_f6 = *(d_float6 *)&srcPtr[srcIdx];
-    // srcNeighborhood_f12->x.x = src_f6.x.x;
-    // srcNeighborhood_f12->x.y = src_f6.y.x;
-    // srcNeighborhood_f12->y.x = src_f6.x.y;
-    // srcNeighborhood_f12->y.y = src_f6.y.y;
-    // srcNeighborhood_f12->z.x = src_f6.x.z;
-    // srcNeighborhood_f12->z.y = src_f6.y.z;
-    // srcIdx += srcStrideH;
-    // src_f6 = *(d_float6 *)&srcPtr[srcIdx];
-    // srcNeighborhood_f12->x.z = src_f6.x.x;
-    // srcNeighborhood_f12->x.w = src_f6.y.x;
-    // srcNeighborhood_f12->y.z = src_f6.x.y;
-    // srcNeighborhood_f12->y.w = src_f6.y.y;
-    // srcNeighborhood_f12->z.z = src_f6.x.z;
-    // srcNeighborhood_f12->z.w = src_f6.y.z;
+    d_half6 src_h6;
+    d_float6 src_f6;
+    d_float6_as_float3s *src_f6f3s = (d_float6_as_float3s *)&src_f6;
+    int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x * 3;
+    src_h6 = *(d_half6 *)&srcPtr[srcIdx];
+    src_f6.x = __half22float2(src_h6.x);
+    src_f6.y = __half22float2(src_h6.y);
+    src_f6.z = __half22float2(src_h6.z);
+    srcNeighborhood_f12->x.x = src_f6f3s->x.x;
+    srcNeighborhood_f12->x.y = src_f6f3s->y.x;
+    srcNeighborhood_f12->y.x = src_f6f3s->x.y;
+    srcNeighborhood_f12->y.y = src_f6f3s->y.y;
+    srcNeighborhood_f12->z.x = src_f6f3s->x.z;
+    srcNeighborhood_f12->z.y = src_f6f3s->y.z;
+    srcIdx += srcStrideH;
+    src_h6 = *(d_half6 *)&srcPtr[srcIdx];
+    src_f6.x = __half22float2(src_h6.x);
+    src_f6.y = __half22float2(src_h6.y);
+    src_f6.z = __half22float2(src_h6.z);
+    srcNeighborhood_f12->x.z = src_f6f3s->x.x;
+    srcNeighborhood_f12->x.w = src_f6f3s->y.x;
+    srcNeighborhood_f12->y.z = src_f6f3s->x.y;
+    srcNeighborhood_f12->y.w = src_f6f3s->y.y;
+    srcNeighborhood_f12->z.z = src_f6f3s->x.z;
+    srcNeighborhood_f12->z.w = src_f6f3s->y.z;
 }
 
 // BILINEAR INTERPOLATION EXECUTION HELPERS (templated execution routines for all bit depths)

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1091,40 +1091,41 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(uchar
 
 __device__ __forceinline__ void rpp_hip_pack_float24_pln3_and_store24_pkd3(float *dstPtr, uint dstIdx, d_float24 *dst_f24)
 {
-    d_float24 *dstPtr_f24;
-    dstPtr_f24 = (d_float24 *)&dstPtr[dstIdx];
+    d_float24 dstPtr_f24;
 
-    dstPtr_f24->x.x.x = dst_f24->x.x.x;
-    dstPtr_f24->x.x.y = dst_f24->y.x.x;
-    dstPtr_f24->x.x.z = dst_f24->z.x.x;
+    dstPtr_f24.x.x.x = dst_f24->x.x.x;
+    dstPtr_f24.x.x.y = dst_f24->y.x.x;
+    dstPtr_f24.x.x.z = dst_f24->z.x.x;
 
-    dstPtr_f24->x.x.w = dst_f24->x.x.y;
-    dstPtr_f24->x.y.x = dst_f24->y.x.y;
-    dstPtr_f24->x.y.y = dst_f24->z.x.y;
+    dstPtr_f24.x.x.w = dst_f24->x.x.y;
+    dstPtr_f24.x.y.x = dst_f24->y.x.y;
+    dstPtr_f24.x.y.y = dst_f24->z.x.y;
 
-    dstPtr_f24->x.y.z = dst_f24->x.x.z;
-    dstPtr_f24->x.y.w = dst_f24->y.x.z;
-    dstPtr_f24->y.x.x = dst_f24->z.x.z;
+    dstPtr_f24.x.y.z = dst_f24->x.x.z;
+    dstPtr_f24.x.y.w = dst_f24->y.x.z;
+    dstPtr_f24.y.x.x = dst_f24->z.x.z;
 
-    dstPtr_f24->y.x.y = dst_f24->x.x.w;
-    dstPtr_f24->y.x.z = dst_f24->y.x.w;
-    dstPtr_f24->y.x.w = dst_f24->z.x.w;
+    dstPtr_f24.y.x.y = dst_f24->x.x.w;
+    dstPtr_f24.y.x.z = dst_f24->y.x.w;
+    dstPtr_f24.y.x.w = dst_f24->z.x.w;
 
-    dstPtr_f24->y.y.x = dst_f24->x.y.x;
-    dstPtr_f24->y.y.y = dst_f24->y.y.x;
-    dstPtr_f24->y.y.z = dst_f24->z.y.x;
+    dstPtr_f24.y.y.x = dst_f24->x.y.x;
+    dstPtr_f24.y.y.y = dst_f24->y.y.x;
+    dstPtr_f24.y.y.z = dst_f24->z.y.x;
 
-    dstPtr_f24->y.y.w = dst_f24->x.y.y;
-    dstPtr_f24->z.x.x = dst_f24->y.y.y;
-    dstPtr_f24->z.x.y = dst_f24->z.y.y;
+    dstPtr_f24.y.y.w = dst_f24->x.y.y;
+    dstPtr_f24.z.x.x = dst_f24->y.y.y;
+    dstPtr_f24.z.x.y = dst_f24->z.y.y;
 
-    dstPtr_f24->z.x.z = dst_f24->x.y.z;
-    dstPtr_f24->z.x.w = dst_f24->y.y.z;
-    dstPtr_f24->z.y.x = dst_f24->z.y.z;
+    dstPtr_f24.z.x.z = dst_f24->x.y.z;
+    dstPtr_f24.z.x.w = dst_f24->y.y.z;
+    dstPtr_f24.z.y.x = dst_f24->z.y.z;
 
-    dstPtr_f24->z.y.y = dst_f24->x.y.w;
-    dstPtr_f24->z.y.z = dst_f24->y.y.w;
-    dstPtr_f24->z.y.w = dst_f24->z.y.w;
+    dstPtr_f24.z.y.y = dst_f24->x.y.w;
+    dstPtr_f24.z.y.z = dst_f24->y.y.w;
+    dstPtr_f24.z.y.w = dst_f24->z.y.w;
+
+    *(d_float24 *)&dstPtr[dstIdx] = dstPtr_f24;
 }
 
 // I8 stores with layout toggle PLN3 to PKD3 (24 I8 pixels)
@@ -1185,6 +1186,46 @@ __device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(uchar
     *((uint2 *)(&dstPtr[dstIdx])) = dst.y;
     dstIdx += increment;
     *((uint2 *)(&dstPtr[dstIdx])) = dst.z;
+}
+
+// F32 stores with layout toggle PKD3 to PLN3 (24 F32 pixels)
+
+__device__ __forceinline__ void rpp_hip_pack_float24_pkd3_and_store24_pln3(float *dstPtr, uint dstIdx, uint increment, d_float24 *dst_f24)
+{
+    d_float24 dstPtr_f24;
+
+    dstPtr_f24.x.x.x = dst_f24->x.x.x;
+    dstPtr_f24.x.x.y = dst_f24->x.x.w;
+    dstPtr_f24.x.x.z = dst_f24->x.y.z;
+    dstPtr_f24.x.x.w = dst_f24->y.x.y;
+    dstPtr_f24.x.y.x = dst_f24->y.y.x;
+    dstPtr_f24.x.y.y = dst_f24->y.y.w;
+    dstPtr_f24.x.y.z = dst_f24->z.x.z;
+    dstPtr_f24.x.y.w = dst_f24->z.y.y;
+
+    dstPtr_f24.y.x.x = dst_f24->x.x.y;
+    dstPtr_f24.y.x.y = dst_f24->x.y.x;
+    dstPtr_f24.y.x.z = dst_f24->x.y.w;
+    dstPtr_f24.y.x.w = dst_f24->y.x.z;
+    dstPtr_f24.y.y.x = dst_f24->y.y.y;
+    dstPtr_f24.y.y.y = dst_f24->z.x.x;
+    dstPtr_f24.y.y.z = dst_f24->z.x.w;
+    dstPtr_f24.y.y.w = dst_f24->z.y.z;
+
+    dstPtr_f24.z.x.x = dst_f24->x.x.z;
+    dstPtr_f24.z.x.y = dst_f24->x.y.y;
+    dstPtr_f24.z.x.z = dst_f24->y.x.x;
+    dstPtr_f24.z.x.w = dst_f24->y.x.w;
+    dstPtr_f24.z.y.x = dst_f24->y.y.z;
+    dstPtr_f24.z.y.y = dst_f24->z.x.y;
+    dstPtr_f24.z.y.z = dst_f24->z.y.x;
+    dstPtr_f24.z.y.w = dst_f24->z.y.w;
+
+    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.x;
+    dstIdx += increment;
+    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.y;
+    dstIdx += increment;
+    *(d_float8 *)&dstPtr[dstIdx] = dstPtr_f24.z;
 }
 
 // -------------------- Set 6 - Loads to uchar --------------------
@@ -1519,7 +1560,7 @@ __device__ __forceinline__ void rpp_hip_math_subtract24_const(d_float24 *src_f24
 
 /******************** DEVICE INTERPOLATION HELPER FUNCTIONS ********************/
 
-// BILINEAR INTERPOLATION LOAD HELPERS
+// BILINEAR INTERPOLATION LOAD HELPERS (separate load routines for each bit depth)
 
 // U8 loads for bilinear interpolation (4 U8 pixels)
 
@@ -1534,6 +1575,21 @@ __device__ __forceinline__ void rpp_hip_interpolate1_bilinear_load_pln1(uchar *s
     src = *(uint *)&srcPtr[srcIdx];
     srcNeighborhood_f4->z = rpp_hip_unpack0(src);
     srcNeighborhood_f4->w = rpp_hip_unpack1(src);
+}
+
+// F32 loads for bilinear interpolation (4 F32 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate1_bilinear_load_pln1(float *srcPtr, uint srcStrideH, float2 *locSrcFloor, float4 *srcNeighborhood_f4)
+{
+    float2 src_f2;
+    int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x;
+    src_f2 = *(float2 *)&srcPtr[srcIdx];
+    srcNeighborhood_f4->x = src_f2.x;
+    srcNeighborhood_f4->y = src_f2.y;
+    srcIdx += srcStrideH;
+    src_f2 = *(float2 *)&srcPtr[srcIdx];
+    srcNeighborhood_f4->z = src_f2.x;
+    srcNeighborhood_f4->w = src_f2.y;
 }
 
 // U8 loads for bilinear interpolation (12 U8 pixels)
@@ -1559,7 +1615,30 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(uchar *s
     srcNeighborhood_f12->z.w = rpp_hip_unpack1(src_u2.y);
 }
 
-// BILINEAR INTERPOLATION EXECUTION HELPERS
+// F32 loads for bilinear interpolation (12 F32 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(float *srcPtr, uint srcStrideH, float2 *locSrcFloor, d_float12 *srcNeighborhood_f12)
+{
+    d_float6 src_f6;
+    int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x * 3;
+    src_f6 = *(d_float6 *)&srcPtr[srcIdx];
+    srcNeighborhood_f12->x.x = src_f6.x.x;
+    srcNeighborhood_f12->x.y = src_f6.y.x;
+    srcNeighborhood_f12->y.x = src_f6.x.y;
+    srcNeighborhood_f12->y.y = src_f6.y.y;
+    srcNeighborhood_f12->z.x = src_f6.x.z;
+    srcNeighborhood_f12->z.y = src_f6.y.z;
+    srcIdx += srcStrideH;
+    src_f6 = *(d_float6 *)&srcPtr[srcIdx];
+    srcNeighborhood_f12->x.z = src_f6.x.x;
+    srcNeighborhood_f12->x.w = src_f6.y.x;
+    srcNeighborhood_f12->y.z = src_f6.x.y;
+    srcNeighborhood_f12->y.w = src_f6.y.y;
+    srcNeighborhood_f12->z.z = src_f6.x.z;
+    srcNeighborhood_f12->z.w = src_f6.y.z;
+}
+
+// BILINEAR INTERPOLATION EXECUTION HELPERS (templated execution routines for all bit depths)
 
 // float bilinear interpolation computation
 
@@ -1663,7 +1742,40 @@ __device__ __forceinline__ void rpp_hip_interpolate24_bilinear_pkd3(T *srcPtr, u
     rpp_hip_interpolate3_bilinear_pkd3(srcPtr, srcStrideH, locPtrSrc_f16->x.y.w, locPtrSrc_f16->y.y.w, roiPtrSrc, &(dst_f24->y.w));
 }
 
-// NEAREST NEIGHBOR INTERPOLATION EXECUTION HELPERS
+// NEAREST NEIGHBOR INTERPOLATION LOAD HELPERS (separate load routines for each bit depth)
+
+// U8 loads for nearest_neighbor interpolation (4 U8 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate1_nearest_neighbor_load_pln1(uchar *srcPtr, int srcIdx, float *dst)
+{
+    uint src = *(uint *)&srcPtr[srcIdx];
+    *dst = rpp_hip_unpack0(src);
+}
+
+// F32 loads for nearest_neighbor interpolation (4 F32 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate1_nearest_neighbor_load_pln1(float *srcPtr, int srcIdx, float *dst)
+{
+    *dst = srcPtr[srcIdx];
+}
+
+// U8 loads for nearest_neighbor interpolation (12 U8 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate3_nearest_neighbor_load_pkd3(uchar *srcPtr, int srcIdx, float3 *dst_f3)
+{
+    uint src = *(uint *)&srcPtr[srcIdx];
+    *dst_f3 = make_float3(rpp_hip_unpack0(src), rpp_hip_unpack1(src), rpp_hip_unpack2(src));
+}
+
+// F32 loads for nearest_neighbor interpolation (12 F32 pixels)
+
+__device__ __forceinline__ void rpp_hip_interpolate3_nearest_neighbor_load_pkd3(float *srcPtr, int srcIdx, float3 *dst_f3)
+{
+    float3 src_f3 = *(float3 *)&srcPtr[srcIdx];
+    *dst_f3 = src_f3;
+}
+
+// NEAREST NEIGHBOR INTERPOLATION EXECUTION HELPERS (templated execution routines for all bit depths)
 
 // float nearest neighbor interpolation pln1
 
@@ -1681,7 +1793,7 @@ __device__ __forceinline__ void rpp_hip_interpolate1_nearest_neighbor_pln1(T *sr
     else
     {
         int srcIdx = locSrc.y * srcStrideH + locSrc.x;
-        *dst = rpp_hip_unpack0(*(uint *)&srcPtr[srcIdx]);
+        rpp_hip_interpolate1_nearest_neighbor_load_pln1(srcPtr, srcIdx, dst);
     }
 }
 
@@ -1702,8 +1814,7 @@ __device__ __forceinline__ void rpp_hip_interpolate3_nearest_neighbor_pkd3(T *sr
     {
         uint src;
         int srcIdx = locSrc.y * srcStrideH + locSrc.x * 3;
-        src = *(uint *)&srcPtr[srcIdx];
-        *dst_f3 = make_float3(rpp_hip_unpack0(src), rpp_hip_unpack1(src), rpp_hip_unpack2(src));
+        rpp_hip_interpolate3_nearest_neighbor_load_pkd3(srcPtr, srcIdx, dst_f3);
     }
 }
 

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1579,7 +1579,7 @@ __device__ __forceinline__ void rpp_hip_interpolate1_bilinear_pln1(T *srcPtr, ui
     float2 locSrcFloor, weightedWH, oneMinusWeightedWH;
     locSrcFloor.x = floorf(locSrcX);
     locSrcFloor.y = floorf(locSrcY);
-    if ((locSrcFloor.x < roiPtrSrc->x.x) || (locSrcFloor.y < roiPtrSrc->x.y) || (locSrcFloor.x + 1 > roiPtrSrc->y.x) || (locSrcFloor.y + 1 > roiPtrSrc->y.y))
+    if ((locSrcFloor.x < roiPtrSrc->x.x) || (locSrcFloor.y < roiPtrSrc->x.y) || (locSrcFloor.x > roiPtrSrc->y.x) || (locSrcFloor.y > roiPtrSrc->y.y))
     {
         *dst = 0.0f;
     }
@@ -1603,7 +1603,7 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_pkd3(T *srcPtr, ui
     float2 locSrcFloor, weightedWH, oneMinusWeightedWH;
     locSrcFloor.x = floorf(locSrcX);
     locSrcFloor.y = floorf(locSrcY);
-    if ((locSrcFloor.x < roiPtrSrc->x.x) || (locSrcFloor.y < roiPtrSrc->x.y) || (locSrcFloor.x + 1 > roiPtrSrc->y.x) || (locSrcFloor.y + 1 > roiPtrSrc->y.y))
+    if ((locSrcFloor.x < roiPtrSrc->x.x) || (locSrcFloor.y < roiPtrSrc->x.y) || (locSrcFloor.x > roiPtrSrc->y.x) || (locSrcFloor.y > roiPtrSrc->y.y))
     {
         dst_f3->x = 0.0f;
         dst_f3->y = 0.0f;

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1754,29 +1754,28 @@ __device__ __forceinline__ void rpp_hip_interpolate3_bilinear_load_pkd3(half *sr
 {
     d_half6 src_h6;
     d_float6 src_f6;
-    d_float6_as_float3s *src_f6f3s = (d_float6_as_float3s *)&src_f6;
     int srcIdx = (int)locSrcFloor->y * srcStrideH + (int)locSrcFloor->x * 3;
     src_h6 = *(d_half6 *)&srcPtr[srcIdx];
     src_f6.x = __half22float2(src_h6.x);
     src_f6.y = __half22float2(src_h6.y);
     src_f6.z = __half22float2(src_h6.z);
-    srcNeighborhood_f12->x.x = src_f6f3s->x.x;
-    srcNeighborhood_f12->x.y = src_f6f3s->y.x;
-    srcNeighborhood_f12->y.x = src_f6f3s->x.y;
-    srcNeighborhood_f12->y.y = src_f6f3s->y.y;
-    srcNeighborhood_f12->z.x = src_f6f3s->x.z;
-    srcNeighborhood_f12->z.y = src_f6f3s->y.z;
+    srcNeighborhood_f12->x.x = src_f6.x.x;
+    srcNeighborhood_f12->x.y = src_f6.y.y;
+    srcNeighborhood_f12->y.x = src_f6.x.y;
+    srcNeighborhood_f12->y.y = src_f6.z.x;
+    srcNeighborhood_f12->z.x = src_f6.y.x;
+    srcNeighborhood_f12->z.y = src_f6.z.y;
     srcIdx += srcStrideH;
     src_h6 = *(d_half6 *)&srcPtr[srcIdx];
     src_f6.x = __half22float2(src_h6.x);
     src_f6.y = __half22float2(src_h6.y);
     src_f6.z = __half22float2(src_h6.z);
-    srcNeighborhood_f12->x.z = src_f6f3s->x.x;
-    srcNeighborhood_f12->x.w = src_f6f3s->y.x;
-    srcNeighborhood_f12->y.z = src_f6f3s->x.y;
-    srcNeighborhood_f12->y.w = src_f6f3s->y.y;
-    srcNeighborhood_f12->z.z = src_f6f3s->x.z;
-    srcNeighborhood_f12->z.w = src_f6f3s->y.z;
+    srcNeighborhood_f12->x.z = src_f6.x.x;
+    srcNeighborhood_f12->x.w = src_f6.y.y;
+    srcNeighborhood_f12->y.z = src_f6.x.y;
+    srcNeighborhood_f12->y.w = src_f6.z.x;
+    srcNeighborhood_f12->z.z = src_f6.y.x;
+    srcNeighborhood_f12->z.w = src_f6.z.y;
 }
 
 // BILINEAR INTERPOLATION EXECUTION HELPERS (templated execution routines for all bit depths)

--- a/src/include/hip/rpp_hip_roi_conversion.hpp
+++ b/src/include/hip/rpp_hip_roi_conversion.hpp
@@ -3,6 +3,8 @@
 
 #include <hip/hip_runtime.h>
 
+// LTRB to XYWH
+
 static __global__ void roi_converison_ltrb_to_xywh(int *roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 4;
@@ -15,7 +17,7 @@ static __global__ void roi_converison_ltrb_to_xywh(int *roiTensorPtrSrc)
 }
 
 static RppStatus hip_exec_roi_converison_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc,
-                                               rpp::Handle& handle)
+                                                      rpp::Handle& handle)
 {
     int localThreads_x = 256;
     int localThreads_y = 1;
@@ -25,6 +27,39 @@ static RppStatus hip_exec_roi_converison_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc
     int globalThreads_z = 1;
 
     hipLaunchKernelGGL(roi_converison_ltrb_to_xywh,
+                       dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                       dim3(localThreads_x, localThreads_y, localThreads_z),
+                       0,
+                       handle.GetStream(),
+                       (int *) roiTensorPtrSrc);
+
+    return RPP_SUCCESS;
+}
+
+// XYWH to LTRB
+
+static __global__ void roi_converison_xywh_to_ltrb(int *roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 4;
+
+    int4 *roiTensorPtrSrc_i4;
+    roiTensorPtrSrc_i4 = (int4 *)&roiTensorPtrSrc[id_x];
+
+    roiTensorPtrSrc_i4->z += (roiTensorPtrSrc_i4->x - 1);
+    roiTensorPtrSrc_i4->w += (roiTensorPtrSrc_i4->y - 1);
+}
+
+static RppStatus hip_exec_roi_converison_xywh_to_ltrb(RpptROIPtr roiTensorPtrSrc,
+                                                      rpp::Handle& handle)
+{
+    int localThreads_x = 256;
+    int localThreads_y = 1;
+    int localThreads_z = 1;
+    int globalThreads_x = handle.GetBatchSize();
+    int globalThreads_y = 1;
+    int globalThreads_z = 1;
+
+    hipLaunchKernelGGL(roi_converison_xywh_to_ltrb,
                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                        dim3(localThreads_x, localThreads_y, localThreads_z),
                        0,

--- a/src/modules/hip/hip_tensor_geometric_augmentations.hpp
+++ b/src/modules/hip/hip_tensor_geometric_augmentations.hpp
@@ -24,5 +24,6 @@ THE SOFTWARE.
 #define HIP_TENSOR_GEOMETRIC_AUGMENTATIONS_HPP
 
 #include "kernel/crop.hpp"
+#include "kernel/warp_affine.hpp"
 
 #endif // HIP_TENSOR_GEOMETRIC_AUGMENTATIONS_HPP

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -15,7 +15,7 @@ __device__ void warp_affine_srclocs_hip_compute(float affineMatrixElement, float
     locSrcPtr_f8->y = locSrcComponent_f4 + increment_f8.y;
 }
 
-__device__ void warp_affine_roi_and_srclocs_hip_compute(d_int4 *roiSrc, int id_x, int id_y, d_float6 *affineMatrix_f6, d_float16 *locSrc_f16)
+__device__ void warp_affine_roi_and_srclocs_hip_compute(d_int4 *roiSrc, int id_x, int id_y, d_float6_as_float3s *affineMatrix_f6, d_float16 *locSrc_f16)
 {
     float2 locDst_f2, locSrc_f2;
     int roiHalfWidth = (roiSrc->y.x - roiSrc->x.x + 1) >> 1;
@@ -38,7 +38,7 @@ __global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
                                                 uint2 dstDimsWH,
-                                                d_float6 *affineTensorPtr,
+                                                d_float6_as_float3s *affineTensorPtr,
                                                 RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -53,7 +53,7 @@ __global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNH.x);
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -70,7 +70,7 @@ __global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
                                                 uint3 dstStridesNCH,
                                                 uint2 dstDimsWH,
                                                 int channelsDst,
-                                                d_float6 *affineTensorPtr,
+                                                d_float6_as_float3s *affineTensorPtr,
                                                 RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -85,7 +85,7 @@ __global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNCH.x);
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -116,7 +116,7 @@ __global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
                                                       T *dstPtr,
                                                       uint3 dstStridesNCH,
                                                       uint2 dstDimsWH,
-                                                      d_float6 *affineTensorPtr,
+                                                      d_float6_as_float3s *affineTensorPtr,
                                                       RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -131,7 +131,7 @@ __global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNH.x);
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -147,7 +147,7 @@ __global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
                                                       T *dstPtr,
                                                       uint2 dstStridesNH,
                                                       uint2 dstDimsWH,
-                                                      d_float6 *affineTensorPtr,
+                                                      d_float6_as_float3s *affineTensorPtr,
                                                       RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -162,7 +162,7 @@ __global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNCH.x);
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -180,7 +180,7 @@ __global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
                                                 uint2 dstDimsWH,
-                                                d_float6 *affineTensorPtr,
+                                                d_float6_as_float3s *affineTensorPtr,
                                                 RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -195,7 +195,7 @@ __global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNH.x);
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -212,7 +212,7 @@ __global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
                                                         uint3 dstStridesNCH,
                                                         uint2 dstDimsWH,
                                                         int channelsDst,
-                                                        d_float6 *affineTensorPtr,
+                                                        d_float6_as_float3s *affineTensorPtr,
                                                         RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -227,7 +227,7 @@ __global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNCH.x);
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -258,7 +258,7 @@ __global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
                                                               T *dstPtr,
                                                               uint3 dstStridesNCH,
                                                               uint2 dstDimsWH,
-                                                              d_float6 *affineTensorPtr,
+                                                              d_float6_as_float3s *affineTensorPtr,
                                                               RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -273,7 +273,7 @@ __global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNH.x);
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -289,7 +289,7 @@ __global__ void warp_affine_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
                                                               T *dstPtr,
                                                               uint2 dstStridesNH,
                                                               uint2 dstDimsWH,
-                                                              d_float6 *affineTensorPtr,
+                                                              d_float6_as_float3s *affineTensorPtr,
                                                               RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
@@ -304,7 +304,7 @@ __global__ void warp_affine_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
     uint srcIdx = (id_z * srcStridesNCH.x);
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
 
-    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_float6_as_float3s affineMatrix_f6 = affineTensorPtr[id_z];
     d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
     d_float16 locSrc_f16;
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
@@ -354,7 +354,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                             dstPtr,
                             make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
                             make_uint2(dstDescPtr->w, dstDescPtr->h),
-                            (d_float6 *)affineTensorPtr,
+                            (d_float6_as_float3s *)affineTensorPtr,
                             roiTensorPtrSrc);
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
@@ -370,7 +370,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                             make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
                             make_uint2(dstDescPtr->w, dstDescPtr->h),
                             dstDescPtr->c,
-                            (d_float6 *)affineTensorPtr,
+                            (d_float6_as_float3s *)affineTensorPtr,
                             roiTensorPtrSrc);
         }
         else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
@@ -387,7 +387,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                                 dstPtr,
                                 make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
                                 make_uint2(dstDescPtr->w, dstDescPtr->h),
-                                (d_float6 *)affineTensorPtr,
+                                (d_float6_as_float3s *)affineTensorPtr,
                                 roiTensorPtrSrc);
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
@@ -403,7 +403,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                                 dstPtr,
                                 make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
                                 make_uint2(dstDescPtr->w, dstDescPtr->h),
-                                (d_float6 *)affineTensorPtr,
+                                (d_float6_as_float3s *)affineTensorPtr,
                                 roiTensorPtrSrc);
             }
         }
@@ -422,7 +422,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                             dstPtr,
                             make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
                             make_uint2(dstDescPtr->w, dstDescPtr->h),
-                            (d_float6 *)affineTensorPtr,
+                            (d_float6_as_float3s *)affineTensorPtr,
                             roiTensorPtrSrc);
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
@@ -438,7 +438,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                             make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
                             make_uint2(dstDescPtr->w, dstDescPtr->h),
                             dstDescPtr->c,
-                            (d_float6 *)affineTensorPtr,
+                            (d_float6_as_float3s *)affineTensorPtr,
                             roiTensorPtrSrc);
         }
         else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
@@ -455,7 +455,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                                 dstPtr,
                                 make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
                                 make_uint2(dstDescPtr->w, dstDescPtr->h),
-                                (d_float6 *)affineTensorPtr,
+                                (d_float6_as_float3s *)affineTensorPtr,
                                 roiTensorPtrSrc);
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
@@ -471,7 +471,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                                 dstPtr,
                                 make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
                                 make_uint2(dstDescPtr->w, dstDescPtr->h),
-                                (d_float6 *)affineTensorPtr,
+                                (d_float6_as_float3s *)affineTensorPtr,
                                 roiTensorPtrSrc);
             }
         }

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -59,8 +59,8 @@ __global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24_as_float3s dst_f24;
-    rpp_hip_interpolate24_bilinear_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr, dstIdx, (d_float24 *)&dst_f24);
+    rpp_hip_interpolate24_bilinear_pkd3(srcPtr + srcIdx, srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr + dstIdx, (d_float24 *)&dst_f24);
 }
 
 template <typename T>
@@ -91,22 +91,22 @@ __global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float8 dst_f8;
-    rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-    rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+    rpp_hip_interpolate8_bilinear_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
 
     if (channelsDst == 3)
     {
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+        rpp_hip_interpolate8_bilinear_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
 
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+        rpp_hip_interpolate8_bilinear_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
     }
 }
 
@@ -137,8 +137,8 @@ __global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24_as_float3s dst_f24;
-    rpp_hip_interpolate24_bilinear_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr, dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
+    rpp_hip_interpolate24_bilinear_pkd3(srcPtr + srcIdx, srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
 }
 
 template <typename T>
@@ -168,8 +168,8 @@ __global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24 dst_f24;
-    rpp_hip_interpolate24_bilinear_pln3(&srcPtr[srcIdx], &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr, dstIdx, &dst_f24);
+    rpp_hip_interpolate24_bilinear_pln3(srcPtr + srcIdx, &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
 }
 
 // -------------------- Set 2 - Nearest Neighbor Interpolation --------------------
@@ -201,8 +201,8 @@ __global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24_as_float3s dst_f24;
-    rpp_hip_interpolate24_nearest_neighbor_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr, dstIdx, (d_float24 *)&dst_f24);
+    rpp_hip_interpolate24_nearest_neighbor_pkd3(srcPtr + srcIdx, srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr + dstIdx, (d_float24 *)&dst_f24);
 }
 
 template <typename T>
@@ -233,22 +233,22 @@ __global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float8 dst_f8;
-    rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-    rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+    rpp_hip_interpolate8_nearest_neighbor_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
 
     if (channelsDst == 3)
     {
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+        rpp_hip_interpolate8_nearest_neighbor_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
 
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+        rpp_hip_interpolate8_nearest_neighbor_pln1(srcPtr + srcIdx, srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
     }
 }
 
@@ -279,8 +279,8 @@ __global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24_as_float3s dst_f24;
-    rpp_hip_interpolate24_nearest_neighbor_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr, dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
+    rpp_hip_interpolate24_nearest_neighbor_pkd3(srcPtr + srcIdx, srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
 }
 
 template <typename T>
@@ -310,8 +310,8 @@ __global__ void warp_affine_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
     warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
 
     d_float24 dst_f24;
-    rpp_hip_interpolate24_nearest_neighbor_pln3(&srcPtr[srcIdx], &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
-    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr, dstIdx, &dst_f24);
+    rpp_hip_interpolate24_nearest_neighbor_pln3(srcPtr + srcIdx, &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
 }
 
 // -------------------- Set 3 - Kernel Executors --------------------

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -6,10 +6,7 @@
 __device__ void warp_affine_srclocs_hip_compute(float affineMatrixElement, float4 locSrcComponent_f4, d_float8 *locSrcPtr_f8)
 {
     d_float8 increment_f8;
-    increment_f8.x.x = 0;
-    increment_f8.x.y = affineMatrixElement;
-    increment_f8.x.z = affineMatrixElement + increment_f8.x.y;
-    increment_f8.x.w = affineMatrixElement + increment_f8.x.z;
+    increment_f8.x = make_float4(0, affineMatrixElement, affineMatrixElement + affineMatrixElement, affineMatrixElement + affineMatrixElement + affineMatrixElement);
     increment_f8.y = (float4)(affineMatrixElement + increment_f8.x.w) + increment_f8.x;
     locSrcPtr_f8->x = locSrcComponent_f4 + increment_f8.x;
     locSrcPtr_f8->y = locSrcComponent_f4 + increment_f8.y;

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -1,0 +1,294 @@
+#include <hip/hip_runtime.h>
+#include "hip/rpp_hip_common.hpp"
+
+__device__ void warp_affine_srclocs_hip_compute(float affineMatrixElement, float4 locSrcComponent_f4, d_float8 *locSrcPtr_f8)
+{
+    d_float8 increment_f8;
+    increment_f8.x.x = 0;
+    increment_f8.x.y = affineMatrixElement;
+    increment_f8.x.z = affineMatrixElement + increment_f8.x.y;
+    increment_f8.x.w = affineMatrixElement + increment_f8.x.z;
+    increment_f8.y = (float4)(affineMatrixElement + increment_f8.x.w) + increment_f8.x;
+    locSrcPtr_f8->x = locSrcComponent_f4 + increment_f8.x;
+    locSrcPtr_f8->y = locSrcComponent_f4 + increment_f8.y;
+}
+
+template <typename T>
+__global__ void warp_affine_pkd_tensor(T *srcPtr,
+                                       uint2 srcStridesNH,
+                                       T *dstPtr,
+                                       uint2 dstStridesNH,
+                                       uint2 dstDimsWH,
+                                       d_float6 *affineTensorPtr,
+                                       RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc;
+    float2 locDst_f2, locSrc_f2;
+    roiSrc.x.x = roiTensorPtrSrc[id_z].xywhROI.xy.x; // probably use ltrb roi?
+    roiSrc.x.y = roiTensorPtrSrc[id_z].xywhROI.xy.y;
+    roiSrc.y.x = roiSrc.x.x + roiTensorPtrSrc[id_z].xywhROI.roiWidth - 1;
+    roiSrc.y.y = roiSrc.x.y + roiTensorPtrSrc[id_z].xywhROI.roiHeight - 1;
+
+    locDst_f2.x = (float) ((id_x) - (roiTensorPtrSrc[id_z].xywhROI.roiWidth >> 1));
+    locDst_f2.y = (float) ((id_y) - (roiTensorPtrSrc[id_z].xywhROI.roiHeight >> 1));
+    locSrc_f2.x = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiWidth, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.x.x, fmaf(locDst_f2.y, affineMatrix_f6.x.y, affineMatrix_f6.x.z)));
+    locSrc_f2.y = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiHeight, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.y.x, fmaf(locDst_f2.y, affineMatrix_f6.y.y, affineMatrix_f6.y.z)));
+
+    d_float16 locSrc_f16;
+    d_float24_as_float3s dst_f24;
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.x.x, (float4)locSrc_f2.x, &(locSrc_f16.x));    // Compute 8 locSrcX
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.y.x, (float4)locSrc_f2.y, &(locSrc_f16.y));    // Compute 8 locSrcY
+
+    rpp_hip_interpolate24_bilinear_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr, dstIdx, (d_float24 *)&dst_f24);
+}
+
+template <typename T>
+__global__ void warp_affine_pln_tensor(T *srcPtr,
+                                       uint3 srcStridesNCH,
+                                       T *dstPtr,
+                                       uint3 dstStridesNCH,
+                                       uint2 dstDimsWH,
+                                       int channelsDst,
+                                       d_float6 *affineTensorPtr,
+                                       RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc;
+    float2 locDst_f2, locSrc_f2;
+    roiSrc.x.x = roiTensorPtrSrc[id_z].xywhROI.xy.x; // probably use ltrb roi?
+    roiSrc.x.y = roiTensorPtrSrc[id_z].xywhROI.xy.y;
+    roiSrc.y.x = roiSrc.x.x + roiTensorPtrSrc[id_z].xywhROI.roiWidth - 1;
+    roiSrc.y.y = roiSrc.x.y + roiTensorPtrSrc[id_z].xywhROI.roiHeight - 1;
+
+    locDst_f2.x = (float) ((id_x) - (roiTensorPtrSrc[id_z].xywhROI.roiWidth >> 1));
+    locDst_f2.y = (float) ((id_y) - (roiTensorPtrSrc[id_z].xywhROI.roiHeight >> 1));
+    locSrc_f2.x = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiWidth, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.x.x, fmaf(locDst_f2.y, affineMatrix_f6.x.y, affineMatrix_f6.x.z)));
+    locSrc_f2.y = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiHeight, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.y.x, fmaf(locDst_f2.y, affineMatrix_f6.y.y, affineMatrix_f6.y.z)));
+
+    d_float16 locSrc_f16;
+    d_float8 dst_f8;
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.x.x, (float4)locSrc_f2.x, &(locSrc_f16.x));    // Compute 8 locSrcX
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.y.x, (float4)locSrc_f2.y, &(locSrc_f16.y));    // Compute 8 locSrcY
+
+    rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+
+    if (channelsDst == 3)
+    {
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_interpolate8_bilinear_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+    }
+}
+
+template <typename T>
+__global__ void warp_affine_pkd3_pln3_tensor(T *srcPtr,
+                                             uint2 srcStridesNH,
+                                             T *dstPtr,
+                                             uint3 dstStridesNCH,
+                                             uint2 dstDimsWH,
+                                             d_float6 *affineTensorPtr,
+                                             RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc;
+    float2 locDst_f2, locSrc_f2;
+    roiSrc.x.x = roiTensorPtrSrc[id_z].xywhROI.xy.x; // probably use ltrb roi?
+    roiSrc.x.y = roiTensorPtrSrc[id_z].xywhROI.xy.y;
+    roiSrc.y.x = roiSrc.x.x + roiTensorPtrSrc[id_z].xywhROI.roiWidth - 1;
+    roiSrc.y.y = roiSrc.x.y + roiTensorPtrSrc[id_z].xywhROI.roiHeight - 1;
+
+    locDst_f2.x = (float) ((id_x) - (roiTensorPtrSrc[id_z].xywhROI.roiWidth >> 1));
+    locDst_f2.y = (float) ((id_y) - (roiTensorPtrSrc[id_z].xywhROI.roiHeight >> 1));
+    locSrc_f2.x = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiWidth, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.x.x, fmaf(locDst_f2.y, affineMatrix_f6.x.y, affineMatrix_f6.x.z)));
+    locSrc_f2.y = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiHeight, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.y.x, fmaf(locDst_f2.y, affineMatrix_f6.y.y, affineMatrix_f6.y.z)));
+
+    d_float16 locSrc_f16;
+    d_float24_as_float3s dst_f24;
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.x.x, (float4)locSrc_f2.x, &(locSrc_f16.x));    // Compute 8 locSrcX
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.y.x, (float4)locSrc_f2.y, &(locSrc_f16.y));    // Compute 8 locSrcY
+
+    rpp_hip_interpolate24_bilinear_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr, dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
+}
+
+template <typename T>
+__global__ void warp_affine_pln3_pkd3_tensor(T *srcPtr,
+                                             uint3 srcStridesNCH,
+                                             T *dstPtr,
+                                             uint2 dstStridesNH,
+                                             uint2 dstDimsWH,
+                                             d_float6 *affineTensorPtr,
+                                             RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc;
+    float2 locDst_f2, locSrc_f2;
+    roiSrc.x.x = roiTensorPtrSrc[id_z].xywhROI.xy.x; // probably use ltrb roi?
+    roiSrc.x.y = roiTensorPtrSrc[id_z].xywhROI.xy.y;
+    roiSrc.y.x = roiSrc.x.x + roiTensorPtrSrc[id_z].xywhROI.roiWidth - 1;
+    roiSrc.y.y = roiSrc.x.y + roiTensorPtrSrc[id_z].xywhROI.roiHeight - 1;
+
+    locDst_f2.x = (float) ((id_x) - (roiTensorPtrSrc[id_z].xywhROI.roiWidth >> 1));
+    locDst_f2.y = (float) ((id_y) - (roiTensorPtrSrc[id_z].xywhROI.roiHeight >> 1));
+    locSrc_f2.x = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiWidth, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.x.x, fmaf(locDst_f2.y, affineMatrix_f6.x.y, affineMatrix_f6.x.z)));
+    locSrc_f2.y = fmaf(roiTensorPtrSrc[id_z].xywhROI.roiHeight, 0.5f, fmaf(locDst_f2.x, affineMatrix_f6.y.x, fmaf(locDst_f2.y, affineMatrix_f6.y.y, affineMatrix_f6.y.z)));
+
+    d_float16 locSrc_f16;
+    d_float24 dst_f24;
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.x.x, (float4)locSrc_f2.x, &(locSrc_f16.x));    // Compute 8 locSrcX
+    warp_affine_srclocs_hip_compute(affineMatrix_f6.y.x, (float4)locSrc_f2.y, &(locSrc_f16.y));    // Compute 8 locSrcY
+
+    rpp_hip_interpolate24_bilinear_pln3(&srcPtr[srcIdx], &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr, dstIdx, &dst_f24);
+}
+
+template <typename T>
+RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
+                                      RpptDescPtr srcDescPtr,
+                                      T *dstPtr,
+                                      RpptDescPtr dstDescPtr,
+                                      Rpp32f *affineTensor,
+                                      RpptROIPtr roiTensorPtrSrc,
+                                      RpptRoiType roiType,
+                                      rpp::Handle& handle)
+{
+    if (roiType == RpptRoiType::LTRB)
+        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+
+    int localThreads_x = 16;
+    int localThreads_y = 16;
+    int localThreads_z = 1;
+    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_y = dstDescPtr->h;
+    int globalThreads_z = handle.GetBatchSize();
+
+    float *affineTensorPtr = handle.GetInitHandle()->mem.mgpu.maskArr.floatmem;
+    hipMemcpy(affineTensorPtr, affineTensor, 6 * handle.GetBatchSize() * sizeof(float), hipMemcpyHostToDevice);
+
+    if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+    {
+        hipLaunchKernelGGL(warp_affine_pkd_tensor,
+                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                           dim3(localThreads_x, localThreads_y, localThreads_z),
+                           0,
+                           handle.GetStream(),
+                           srcPtr,
+                           make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                           dstPtr,
+                           make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                           make_uint2(dstDescPtr->w, dstDescPtr->h),
+                           (d_float6 *)affineTensorPtr,
+                           roiTensorPtrSrc);
+    }
+    else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+    {
+        hipLaunchKernelGGL(warp_affine_pln_tensor,
+                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                           dim3(localThreads_x, localThreads_y, localThreads_z),
+                           0,
+                           handle.GetStream(),
+                           srcPtr,
+                           make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                           dstPtr,
+                           make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                           make_uint2(dstDescPtr->w, dstDescPtr->h),
+                           dstDescPtr->c,
+                           (d_float6 *)affineTensorPtr,
+                           roiTensorPtrSrc);
+    }
+    else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
+    {
+        if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            hipLaunchKernelGGL(warp_affine_pkd3_pln3_tensor,
+                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                               dim3(localThreads_x, localThreads_y, localThreads_z),
+                               0,
+                               handle.GetStream(),
+                               srcPtr,
+                               make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                               dstPtr,
+                               make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                               make_uint2(dstDescPtr->w, dstDescPtr->h),
+                               (d_float6 *)affineTensorPtr,
+                               roiTensorPtrSrc);
+        }
+        else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
+            hipLaunchKernelGGL(warp_affine_pln3_pkd3_tensor,
+                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                               dim3(localThreads_x, localThreads_y, localThreads_z),
+                               0,
+                               handle.GetStream(),
+                               srcPtr,
+                               make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                               dstPtr,
+                               make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                               make_uint2(dstDescPtr->w, dstDescPtr->h),
+                               (d_float6 *)affineTensorPtr,
+                               roiTensorPtrSrc);
+        }
+    }
+
+    return RPP_SUCCESS;
+}

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -1,6 +1,8 @@
 #include <hip/hip_runtime.h>
 #include "hip/rpp_hip_common.hpp"
 
+// -------------------- Set 0 - warp_affine device helpers --------------------
+
 __device__ void warp_affine_srclocs_hip_compute(float affineMatrixElement, float4 locSrcComponent_f4, d_float8 *locSrcPtr_f8)
 {
     d_float8 increment_f8;
@@ -28,14 +30,16 @@ __device__ void warp_affine_roi_and_srclocs_hip_compute(d_int4 *roiSrc, int id_x
     warp_affine_srclocs_hip_compute(affineMatrix_f6->y.x, (float4)locSrc_f2.y, &(locSrc_f16->y));    // Compute 8 locSrcY
 }
 
+// -------------------- Set 1 - Bilinear Interpolation --------------------
+
 template <typename T>
-__global__ void warp_affine_pkd_tensor(T *srcPtr,
-                                       uint2 srcStridesNH,
-                                       T *dstPtr,
-                                       uint2 dstStridesNH,
-                                       uint2 dstDimsWH,
-                                       d_float6 *affineTensorPtr,
-                                       RpptROIPtr roiTensorPtrSrc)
+__global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
+                                                uint2 srcStridesNH,
+                                                T *dstPtr,
+                                                uint2 dstStridesNH,
+                                                uint2 dstDimsWH,
+                                                d_float6 *affineTensorPtr,
+                                                RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
     int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -60,14 +64,14 @@ __global__ void warp_affine_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_pln_tensor(T *srcPtr,
-                                       uint3 srcStridesNCH,
-                                       T *dstPtr,
-                                       uint3 dstStridesNCH,
-                                       uint2 dstDimsWH,
-                                       int channelsDst,
-                                       d_float6 *affineTensorPtr,
-                                       RpptROIPtr roiTensorPtrSrc)
+__global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
+                                                uint3 srcStridesNCH,
+                                                T *dstPtr,
+                                                uint3 dstStridesNCH,
+                                                uint2 dstDimsWH,
+                                                int channelsDst,
+                                                d_float6 *affineTensorPtr,
+                                                RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
     int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -107,13 +111,13 @@ __global__ void warp_affine_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_pkd3_pln3_tensor(T *srcPtr,
-                                             uint2 srcStridesNH,
-                                             T *dstPtr,
-                                             uint3 dstStridesNCH,
-                                             uint2 dstDimsWH,
-                                             d_float6 *affineTensorPtr,
-                                             RpptROIPtr roiTensorPtrSrc)
+__global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
+                                                      uint2 srcStridesNH,
+                                                      T *dstPtr,
+                                                      uint3 dstStridesNCH,
+                                                      uint2 dstDimsWH,
+                                                      d_float6 *affineTensorPtr,
+                                                      RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
     int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -138,13 +142,13 @@ __global__ void warp_affine_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_pln3_pkd3_tensor(T *srcPtr,
-                                             uint3 srcStridesNCH,
-                                             T *dstPtr,
-                                             uint2 dstStridesNH,
-                                             uint2 dstDimsWH,
-                                             d_float6 *affineTensorPtr,
-                                             RpptROIPtr roiTensorPtrSrc)
+__global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
+                                                      uint3 srcStridesNCH,
+                                                      T *dstPtr,
+                                                      uint2 dstStridesNH,
+                                                      uint2 dstDimsWH,
+                                                      d_float6 *affineTensorPtr,
+                                                      RpptROIPtr roiTensorPtrSrc)
 {
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
     int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
@@ -168,12 +172,157 @@ __global__ void warp_affine_pln3_pkd3_tensor(T *srcPtr,
     rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr, dstIdx, &dst_f24);
 }
 
+// -------------------- Set 2 - Nearest Neighbor Interpolation --------------------
+
+template <typename T>
+__global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
+                                                uint2 srcStridesNH,
+                                                T *dstPtr,
+                                                uint2 dstStridesNH,
+                                                uint2 dstDimsWH,
+                                                d_float6 *affineTensorPtr,
+                                                RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
+    d_float16 locSrc_f16;
+    warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
+
+    d_float24_as_float3s dst_f24;
+    rpp_hip_interpolate24_nearest_neighbor_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr, dstIdx, (d_float24 *)&dst_f24);
+}
+
+template <typename T>
+__global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
+                                                        uint3 srcStridesNCH,
+                                                        T *dstPtr,
+                                                        uint3 dstStridesNCH,
+                                                        uint2 dstDimsWH,
+                                                        int channelsDst,
+                                                        d_float6 *affineTensorPtr,
+                                                        RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
+    d_float16 locSrc_f16;
+    warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
+
+    d_float8 dst_f8;
+    rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+
+    if (channelsDst == 3)
+    {
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_interpolate8_nearest_neighbor_pln1(&srcPtr[srcIdx], srcStridesNCH.z, &locSrc_f16, &roiSrc, &dst_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr, dstIdx, &dst_f8);
+    }
+}
+
+template <typename T>
+__global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
+                                                              uint2 srcStridesNH,
+                                                              T *dstPtr,
+                                                              uint3 dstStridesNCH,
+                                                              uint2 dstDimsWH,
+                                                              d_float6 *affineTensorPtr,
+                                                              RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
+    d_float16 locSrc_f16;
+    warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
+
+    d_float24_as_float3s dst_f24;
+    rpp_hip_interpolate24_nearest_neighbor_pkd3(&srcPtr[srcIdx], srcStridesNH.y, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr, dstIdx, dstStridesNCH.y, (d_float24 *)&dst_f24);
+}
+
+template <typename T>
+__global__ void warp_affine_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
+                                                              uint3 srcStridesNCH,
+                                                              T *dstPtr,
+                                                              uint2 dstStridesNH,
+                                                              uint2 dstDimsWH,
+                                                              d_float6 *affineTensorPtr,
+                                                              RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= dstDimsWH.y) || (id_x >= dstDimsWH.x))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    d_float6 affineMatrix_f6 = affineTensorPtr[id_z];
+    d_int4 roiSrc = *(d_int4 *)&roiTensorPtrSrc[id_z];
+    d_float16 locSrc_f16;
+    warp_affine_roi_and_srclocs_hip_compute(&roiSrc, id_x, id_y, &affineMatrix_f6, &locSrc_f16);
+
+    d_float24 dst_f24;
+    rpp_hip_interpolate24_nearest_neighbor_pln3(&srcPtr[srcIdx], &srcStridesNCH, &locSrc_f16, &roiSrc, &dst_f24);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr, dstIdx, &dst_f24);
+}
+
+// -------------------- Set 3 - Kernel Executors --------------------
+
 template <typename T>
 RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
                                       RpptDescPtr srcDescPtr,
                                       T *dstPtr,
                                       RpptDescPtr dstDescPtr,
                                       Rpp32f *affineTensor,
+                                      RpptInterpolationType interpolationType,
                                       RpptROIPtr roiTensorPtrSrc,
                                       RpptRoiType roiType,
                                       rpp::Handle& handle)
@@ -191,69 +340,140 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
     float *affineTensorPtr = handle.GetInitHandle()->mem.mgpu.maskArr.floatmem;
     hipMemcpy(affineTensorPtr, affineTensor, 6 * handle.GetBatchSize() * sizeof(float), hipMemcpyHostToDevice);
 
-    if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+    if (interpolationType == RpptInterpolationType::BILINEAR)
     {
-        hipLaunchKernelGGL(warp_affine_pkd_tensor,
-                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
-                           dim3(localThreads_x, localThreads_y, localThreads_z),
-                           0,
-                           handle.GetStream(),
-                           srcPtr,
-                           make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
-                           dstPtr,
-                           make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
-                           make_uint2(dstDescPtr->w, dstDescPtr->h),
-                           (d_float6 *)affineTensorPtr,
-                           roiTensorPtrSrc);
-    }
-    else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
-    {
-        hipLaunchKernelGGL(warp_affine_pln_tensor,
-                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
-                           dim3(localThreads_x, localThreads_y, localThreads_z),
-                           0,
-                           handle.GetStream(),
-                           srcPtr,
-                           make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
-                           dstPtr,
-                           make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
-                           make_uint2(dstDescPtr->w, dstDescPtr->h),
-                           dstDescPtr->c,
-                           (d_float6 *)affineTensorPtr,
-                           roiTensorPtrSrc);
-    }
-    else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
-    {
-        if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(warp_affine_pkd3_pln3_tensor,
-                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
-                               dim3(localThreads_x, localThreads_y, localThreads_z),
-                               0,
-                               handle.GetStream(),
-                               srcPtr,
-                               make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
-                               dstPtr,
-                               make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
-                               make_uint2(dstDescPtr->w, dstDescPtr->h),
-                               (d_float6 *)affineTensorPtr,
-                               roiTensorPtrSrc);
+            hipLaunchKernelGGL(warp_affine_bilinear_pkd_tensor,
+                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                            dim3(localThreads_x, localThreads_y, localThreads_z),
+                            0,
+                            handle.GetStream(),
+                            srcPtr,
+                            make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                            dstPtr,
+                            make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                            make_uint2(dstDescPtr->w, dstDescPtr->h),
+                            (d_float6 *)affineTensorPtr,
+                            roiTensorPtrSrc);
         }
-        else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(warp_affine_pln3_pkd3_tensor,
-                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
-                               dim3(localThreads_x, localThreads_y, localThreads_z),
-                               0,
-                               handle.GetStream(),
-                               srcPtr,
-                               make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
-                               dstPtr,
-                               make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
-                               make_uint2(dstDescPtr->w, dstDescPtr->h),
-                               (d_float6 *)affineTensorPtr,
-                               roiTensorPtrSrc);
+            hipLaunchKernelGGL(warp_affine_bilinear_pln_tensor,
+                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                            dim3(localThreads_x, localThreads_y, localThreads_z),
+                            0,
+                            handle.GetStream(),
+                            srcPtr,
+                            make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                            dstPtr,
+                            make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                            make_uint2(dstDescPtr->w, dstDescPtr->h),
+                            dstDescPtr->c,
+                            (d_float6 *)affineTensorPtr,
+                            roiTensorPtrSrc);
+        }
+        else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
+        {
+            if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+            {
+                hipLaunchKernelGGL(warp_affine_bilinear_pkd3_pln3_tensor,
+                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                                dim3(localThreads_x, localThreads_y, localThreads_z),
+                                0,
+                                handle.GetStream(),
+                                srcPtr,
+                                make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                                dstPtr,
+                                make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                                make_uint2(dstDescPtr->w, dstDescPtr->h),
+                                (d_float6 *)affineTensorPtr,
+                                roiTensorPtrSrc);
+            }
+            else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+            {
+                globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
+                hipLaunchKernelGGL(warp_affine_bilinear_pln3_pkd3_tensor,
+                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                                dim3(localThreads_x, localThreads_y, localThreads_z),
+                                0,
+                                handle.GetStream(),
+                                srcPtr,
+                                make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                                dstPtr,
+                                make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                                make_uint2(dstDescPtr->w, dstDescPtr->h),
+                                (d_float6 *)affineTensorPtr,
+                                roiTensorPtrSrc);
+            }
+        }
+    }
+    else if (interpolationType == RpptInterpolationType::NEAREST_NEIGHBOR)
+    {
+        if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd_tensor,
+                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                            dim3(localThreads_x, localThreads_y, localThreads_z),
+                            0,
+                            handle.GetStream(),
+                            srcPtr,
+                            make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                            dstPtr,
+                            make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                            make_uint2(dstDescPtr->w, dstDescPtr->h),
+                            (d_float6 *)affineTensorPtr,
+                            roiTensorPtrSrc);
+        }
+        else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln_tensor,
+                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                            dim3(localThreads_x, localThreads_y, localThreads_z),
+                            0,
+                            handle.GetStream(),
+                            srcPtr,
+                            make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                            dstPtr,
+                            make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                            make_uint2(dstDescPtr->w, dstDescPtr->h),
+                            dstDescPtr->c,
+                            (d_float6 *)affineTensorPtr,
+                            roiTensorPtrSrc);
+        }
+        else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
+        {
+            if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+            {
+                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd3_pln3_tensor,
+                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                                dim3(localThreads_x, localThreads_y, localThreads_z),
+                                0,
+                                handle.GetStream(),
+                                srcPtr,
+                                make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                                dstPtr,
+                                make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                                make_uint2(dstDescPtr->w, dstDescPtr->h),
+                                (d_float6 *)affineTensorPtr,
+                                roiTensorPtrSrc);
+            }
+            else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+            {
+                globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
+                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln3_pkd3_tensor,
+                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                                dim3(localThreads_x, localThreads_y, localThreads_z),
+                                0,
+                                handle.GetStream(),
+                                srcPtr,
+                                make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                                dstPtr,
+                                make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                                make_uint2(dstDescPtr->w, dstDescPtr->h),
+                                (d_float6 *)affineTensorPtr,
+                                roiTensorPtrSrc);
+            }
         }
     }
 

--- a/src/modules/rppt_tensor_geometric_augmentations.cpp
+++ b/src/modules/rppt_tensor_geometric_augmentations.cpp
@@ -170,17 +170,18 @@ RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
                                     roiType,
                                     rpp::deref(rppHandle));
     }
-    // else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
-    // {
-    //     warp_affine_hip_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
-    //                            srcDescPtr,
-    //                            (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-    //                            dstDescPtr,
-    //                            affineTensor,
-    //                            roiTensorPtrSrc,
-    //                            roiType,
-    //                            rpp::deref(rppHandle));
-    // }
+    else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
+    {
+        hip_exec_warp_affine_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                    srcDescPtr,
+                                    (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                    dstDescPtr,
+                                    affineTensor,
+                                    interpolationType,
+                                    roiTensorPtrSrc,
+                                    roiType,
+                                    rpp::deref(rppHandle));
+    }
     else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
     {
         hip_exec_warp_affine_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
@@ -193,17 +194,18 @@ RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
                                     roiType,
                                     rpp::deref(rppHandle));
     }
-    // else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
-    // {
-    //     warp_affine_hip_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,
-    //                            srcDescPtr,
-    //                            static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
-    //                            dstDescPtr,
-    //                            affineTensor,
-    //                            roiTensorPtrSrc,
-    //                            roiType,
-    //                            rpp::deref(rppHandle));
-    // }
+    else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
+    {
+        hip_exec_warp_affine_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                    srcDescPtr,
+                                    static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                    dstDescPtr,
+                                    affineTensor,
+                                    interpolationType,
+                                    roiTensorPtrSrc,
+                                    roiType,
+                                    rpp::deref(rppHandle));
+    }
 
     return RPP_SUCCESS;
 #elif defined(OCL_COMPILE)

--- a/src/modules/rppt_tensor_geometric_augmentations.cpp
+++ b/src/modules/rppt_tensor_geometric_augmentations.cpp
@@ -149,11 +149,15 @@ RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
                                RppPtr_t dstPtr,
                                RpptDescPtr dstDescPtr,
                                Rpp32f *affineTensor,
+                               RpptInterpolationType interpolationType,
                                RpptROIPtr roiTensorPtrSrc,
                                RpptRoiType roiType,
                                rppHandle_t rppHandle)
 {
 #ifdef HIP_COMPILE
+    if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+        return RPP_ERROR_NOT_IMPLEMENTED;
+
     if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
     {
         hip_exec_warp_affine_tensor(static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes,
@@ -161,6 +165,7 @@ RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
                                     static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
                                     dstDescPtr,
                                     affineTensor,
+                                    interpolationType,
                                     roiTensorPtrSrc,
                                     roiType,
                                     rpp::deref(rppHandle));

--- a/src/modules/rppt_tensor_geometric_augmentations.cpp
+++ b/src/modules/rppt_tensor_geometric_augmentations.cpp
@@ -141,3 +141,66 @@ RppStatus rppt_crop_host(RppPtr_t srcPtr,
 
     return RPP_SUCCESS;
 }
+
+/******************** warp_affine ********************/
+
+RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
+                               RpptDescPtr srcDescPtr,
+                               RppPtr_t dstPtr,
+                               RpptDescPtr dstDescPtr,
+                               Rpp32f *affineTensor,
+                               RpptROIPtr roiTensorPtrSrc,
+                               RpptRoiType roiType,
+                               rppHandle_t rppHandle)
+{
+#ifdef HIP_COMPILE
+    if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
+    {
+        hip_exec_warp_affine_tensor(static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                    srcDescPtr,
+                                    static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                    dstDescPtr,
+                                    affineTensor,
+                                    roiTensorPtrSrc,
+                                    roiType,
+                                    rpp::deref(rppHandle));
+    }
+    // else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
+    // {
+    //     warp_affine_hip_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+    //                            srcDescPtr,
+    //                            (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+    //                            dstDescPtr,
+    //                            affineTensor,
+    //                            roiTensorPtrSrc,
+    //                            roiType,
+    //                            rpp::deref(rppHandle));
+    // }
+    // else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
+    // {
+    //     warp_affine_hip_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+    //                            srcDescPtr,
+    //                            (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+    //                            dstDescPtr,
+    //                            affineTensor,
+    //                            roiTensorPtrSrc,
+    //                            roiType,
+    //                            rpp::deref(rppHandle));
+    // }
+    // else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
+    // {
+    //     warp_affine_hip_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,
+    //                            srcDescPtr,
+    //                            static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+    //                            dstDescPtr,
+    //                            affineTensor,
+    //                            roiTensorPtrSrc,
+    //                            roiType,
+    //                            rpp::deref(rppHandle));
+    // }
+
+    return RPP_SUCCESS;
+#elif defined(OCL_COMPILE)
+    return RPP_ERROR_NOT_IMPLEMENTED;
+#endif // backend
+}

--- a/src/modules/rppt_tensor_geometric_augmentations.cpp
+++ b/src/modules/rppt_tensor_geometric_augmentations.cpp
@@ -181,17 +181,18 @@ RppStatus rppt_warp_affine_gpu(RppPtr_t srcPtr,
     //                            roiType,
     //                            rpp::deref(rppHandle));
     // }
-    // else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
-    // {
-    //     warp_affine_hip_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
-    //                            srcDescPtr,
-    //                            (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-    //                            dstDescPtr,
-    //                            affineTensor,
-    //                            roiTensorPtrSrc,
-    //                            roiType,
-    //                            rpp::deref(rppHandle));
-    // }
+    else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
+    {
+        hip_exec_warp_affine_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                    srcDescPtr,
+                                    (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                    dstDescPtr,
+                                    affineTensor,
+                                    interpolationType,
+                                    roiTensorPtrSrc,
+                                    roiType,
+                                    rpp::deref(rppHandle));
+    }
     // else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
     // {
     //     warp_affine_hip_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -72,6 +72,9 @@ int main(int argc, char **argv)
     case 2:
         strcpy(funcName, "blend");
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         break;
@@ -692,6 +695,64 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 5)
                 rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 6)
+                missingFuncFlag = 1;
+            else
+                missingFuncFlag = 1;
+
+            break;
+        }
+        case 24:
+        {
+            test_case_name = "warp_affine";
+
+            Rpp32f6 affineTensor_f6[images];
+            Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+            for (i = 0; i < images; i++)
+            {
+                affineTensor_f6[i].data[0] = 1.23;
+                affineTensor_f6[i].data[1] = 0.5;
+                affineTensor_f6[i].data[2] = 0;
+                affineTensor_f6[i].data[3] = -0.8;
+                affineTensor_f6[i].data[4] = 0.83;
+                affineTensor_f6[i].data[5] = 0;
+            }
+
+            // Uncomment to run test case with an xywhROI override
+            /*for (i = 0; i < images; i++)
+            {
+                roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+            }*/
+
+            // Uncomment to run test case with an ltrbROI override
+            /*for (i = 0; i < images; i++)
+                roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+            }
+            roiTypeSrc = RpptRoiType::LTRB;
+            roiTypeDst = RpptRoiType::LTRB;*/
+
+            hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+            start = clock();
+
+            if (ip_bitDepth == 0)
+                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 1)
+                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 2)
+                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 3)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 4)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 5)
+                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 6)
                 missingFuncFlag = 1;
             else

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -81,6 +81,10 @@ int main(int argc, char **argv)
         strcpy(funcName, "blend");
         outputFormatToggle = 0;
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        outputFormatToggle = 0;
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         outputFormatToggle = 0;
@@ -701,6 +705,64 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 5)
                 rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 6)
+                missingFuncFlag = 1;
+            else
+                missingFuncFlag = 1;
+
+            break;
+        }
+        case 24:
+        {
+            test_case_name = "warp_affine";
+
+            Rpp32f6 affineTensor_f6[images];
+            Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+            for (i = 0; i < images; i++)
+            {
+                affineTensor_f6[i].data[0] = 1.23;
+                affineTensor_f6[i].data[1] = 0.5;
+                affineTensor_f6[i].data[2] = 0;
+                affineTensor_f6[i].data[3] = -0.8;
+                affineTensor_f6[i].data[4] = 0.83;
+                affineTensor_f6[i].data[5] = 0;
+            }
+
+            // Uncomment to run test case with an xywhROI override
+            /*for (i = 0; i < images; i++)
+            {
+                roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+            }*/
+
+            // Uncomment to run test case with an ltrbROI override
+            /*for (i = 0; i < images; i++)
+                roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+            }
+            roiTypeSrc = RpptRoiType::LTRB;
+            roiTypeDst = RpptRoiType::LTRB;*/
+
+            hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+            start = clock();
+
+            if (ip_bitDepth == 0)
+                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 1)
+                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 2)
+                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 3)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 4)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 5)
+                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 6)
                 missingFuncFlag = 1;
             else

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -22,6 +22,43 @@ using namespace std;
 #define RPPMAX2(a,b) ((a > b) ? a : b)
 #define RPPMIN2(a,b) ((a < b) ? a : b)
 
+std::string get_interpolation_type(unsigned int val, RpptInterpolationType &interpolationType)
+{
+    switch(val)
+    {
+        case 0:
+        {
+            interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
+            return "NearestNeighbor";
+        }
+        case 2:
+        {
+            interpolationType = RpptInterpolationType::BICUBIC;
+            return "Bicubic";
+        }
+        case 3:
+        {
+            interpolationType = RpptInterpolationType::LANCZOS;
+            return "Lanczos";
+        }
+        case 4:
+        {
+            interpolationType = RpptInterpolationType::TRIANGULAR;
+            return "Triangular";
+        }
+        case 5:
+        {
+            interpolationType = RpptInterpolationType::GAUSSIAN;
+            return "Gaussian";
+        }
+        default:
+        {
+            interpolationType = RpptInterpolationType::BILINEAR;
+            return "Bilinear";
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -45,10 +82,13 @@ int main(int argc, char **argv)
     int ip_bitDepth = atoi(argv[3]);
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
-    unsigned int verbosity = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[7]) : atoi(argv[6]);
-    unsigned int additionalParam = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[6]) : 1;
-    char additionalParam_char[2];
-    std::sprintf(additionalParam_char, "%u", additionalParam);
+
+    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
+    bool interpolationTypeCase = (test_case == 24);
+
+    unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
+    unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
 
     if (verbosity == 1)
     {
@@ -203,10 +243,21 @@ int main(int argc, char **argv)
     char func[1000];
     strcpy(func, funcName);
     strcat(func, funcType);
-    if (test_case == 40 || test_case == 41 || test_case == 49)
+
+    RpptInterpolationType interpolationType = RpptInterpolationType::BILINEAR;
+    if (kernelSizeCase)
     {
+        char additionalParam_char[2];
+        std::sprintf(additionalParam_char, "%u", additionalParam);
         strcat(func, "_kSize");
         strcat(func, additionalParam_char);
+    }
+    else if (interpolationTypeCase)
+    {
+        std::string interpolationTypeName;
+        interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
+        strcat(func, "_interpolationType");
+        strcat(func, interpolationTypeName.c_str());
     }
 
     // Get number of images
@@ -716,6 +767,12 @@ int main(int argc, char **argv)
         {
             test_case_name = "warp_affine";
 
+            if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+
             Rpp32f6 affineTensor_f6[images];
             Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
             for (i = 0; i < images; i++)
@@ -752,17 +809,17 @@ int main(int argc, char **argv)
             start = clock();
 
             if (ip_bitDepth == 0)
-                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 1)
-                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 2)
-                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 3)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 4)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 5)
-                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 6)
                 missingFuncFlag = 1;
             else

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -72,6 +72,9 @@ int main(int argc, char **argv)
     case 2:
         strcpy(funcName, "blend");
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         break;
@@ -768,6 +771,64 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 5)
                 rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 6)
+                missingFuncFlag = 1;
+            else
+                missingFuncFlag = 1;
+
+            break;
+        }
+        case 24:
+        {
+            test_case_name = "warp_affine";
+
+            Rpp32f6 affineTensor_f6[images];
+            Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+            for (i = 0; i < images; i++)
+            {
+                affineTensor_f6[i].data[0] = 1.23;
+                affineTensor_f6[i].data[1] = 0.5;
+                affineTensor_f6[i].data[2] = 0;
+                affineTensor_f6[i].data[3] = -0.8;
+                affineTensor_f6[i].data[4] = 0.83;
+                affineTensor_f6[i].data[5] = 0;
+            }
+
+            // Uncomment to run test case with an xywhROI override
+            /*for (i = 0; i < images; i++)
+            {
+                roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+            }*/
+
+            // Uncomment to run test case with an ltrbROI override
+            /*for (i = 0; i < images; i++)
+                roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+            }
+            roiTypeSrc = RpptRoiType::LTRB;
+            roiTypeDst = RpptRoiType::LTRB;*/
+
+            hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+            start = clock();
+
+            if (ip_bitDepth == 0)
+                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 1)
+                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 2)
+                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            else if (ip_bitDepth == 3)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 4)
+                missingFuncFlag = 1;
+            else if (ip_bitDepth == 5)
+                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 6)
                 missingFuncFlag = 1;
             else

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -21,6 +21,43 @@ using namespace std;
 #define RPPMAX2(a,b) ((a > b) ? a : b)
 #define RPPMIN2(a,b) ((a < b) ? a : b)
 
+std::string get_interpolation_type(unsigned int val, RpptInterpolationType &interpolationType)
+{
+    switch(val)
+    {
+        case 0:
+        {
+            interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
+            return "NearestNeighbor";
+        }
+        case 2:
+        {
+            interpolationType = RpptInterpolationType::BICUBIC;
+            return "Bicubic";
+        }
+        case 3:
+        {
+            interpolationType = RpptInterpolationType::LANCZOS;
+            return "Lanczos";
+        }
+        case 4:
+        {
+            interpolationType = RpptInterpolationType::TRIANGULAR;
+            return "Triangular";
+        }
+        case 5:
+        {
+            interpolationType = RpptInterpolationType::GAUSSIAN;
+            return "Gaussian";
+        }
+        default:
+        {
+            interpolationType = RpptInterpolationType::BILINEAR;
+            return "Bilinear";
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -39,10 +76,13 @@ int main(int argc, char **argv)
     int ip_bitDepth = atoi(argv[3]);
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
-    unsigned int verbosity = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[7]) : atoi(argv[6]);
-    unsigned int additionalParam = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[6]) : 1;
-    char additionalParam_char[2];
-    std::sprintf(additionalParam_char, "%u", additionalParam);
+
+    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
+    bool interpolationTypeCase = (test_case == 24);
+
+    unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
+    unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
 
     if (verbosity == 1)
     {
@@ -195,10 +235,21 @@ int main(int argc, char **argv)
     char func[1000];
     strcpy(func, funcName);
     strcat(func, funcType);
-    if (test_case == 40 || test_case == 41 || test_case == 49)
+
+    RpptInterpolationType interpolationType = RpptInterpolationType::BILINEAR;
+    if (kernelSizeCase)
     {
+        char additionalParam_char[2];
+        std::sprintf(additionalParam_char, "%u", additionalParam);
         strcat(func, "_kSize");
         strcat(func, additionalParam_char);
+    }
+    else if (interpolationTypeCase)
+    {
+        std::string interpolationTypeName;
+        interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
+        strcat(func, "_interpolationType");
+        strcat(func, interpolationTypeName.c_str());
     }
 
     // Get number of images
@@ -782,6 +833,12 @@ int main(int argc, char **argv)
         {
             test_case_name = "warp_affine";
 
+            if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+
             Rpp32f6 affineTensor_f6[images];
             Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
             for (i = 0; i < images; i++)
@@ -818,17 +875,17 @@ int main(int argc, char **argv)
             start = clock();
 
             if (ip_bitDepth == 0)
-                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 1)
-                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 2)
-                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 3)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 4)
                 missingFuncFlag = 1;
             else if (ip_bitDepth == 5)
-                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
             else if (ip_bitDepth == 6)
                 missingFuncFlag = 1;
             else

--- a/utilities/rpp-performancetests/HIP_NEW/generatePerformanceLogs.py
+++ b/utilities/rpp-performancetests/HIP_NEW/generatePerformanceLogs.py
@@ -192,10 +192,34 @@ elif profilingOption == "YES":
 
                     if (CASE_NUM == 40 or CASE_NUM == 41 or CASE_NUM == 49) and TYPE.startswith("Tensor"):
                         KSIZE_LIST = [3, 5, 7, 9]
-                        # Loop through extra param kSize for box_filter
+                        # Loop through extra param kSize
                         for KSIZE in KSIZE_LIST:
                             # Write into csv file
                             CASE_FILE_PATH = CASE_RESULTS_DIR + "/output_case" + str(CASE_NUM) + "_bitDepth" + str(BIT_DEPTH) + "_oft" + str(OFT) + "_kSize" + str(KSIZE) + ".stats.csv"
+                            print("CASE_FILE_PATH = " + CASE_FILE_PATH)
+                            try:
+                                case_file = open(CASE_FILE_PATH,'r')
+                                for line in case_file:
+                                    print(line)
+                                    if not(line.startswith('"Name"')):
+                                        if TYPE in TENSOR_TYPE_LIST:
+                                            new_file.write(line)
+                                            d_counter[TYPE] = d_counter[TYPE] + 1
+                                        elif TYPE in BATCHPD_TYPE_LIST:
+                                            if prev != line.split(",")[0]:
+                                                new_file.write(line)
+                                                prev = line.split(",")[0]
+                                                d_counter[TYPE] = d_counter[TYPE] + 1
+                                case_file.close()
+                            except IOError:
+                                print("Unable to open case results")
+                                continue
+                    elif (CASE_NUM == 24) and TYPE.startswith("Tensor"):
+                        INTERPOLATIONTYPE_LIST = [0, 1, 2, 3, 4, 5]
+                        # Loop through extra param interpolationType
+                        for INTERPOLATIONTYPE in INTERPOLATIONTYPE_LIST:
+                            # Write into csv file
+                            CASE_FILE_PATH = CASE_RESULTS_DIR + "/output_case" + str(CASE_NUM) + "_bitDepth" + str(BIT_DEPTH) + "_oft" + str(OFT) + "_interpolationType" + str(INTERPOLATIONTYPE) + ".stats.csv"
                             print("CASE_FILE_PATH = " + CASE_FILE_PATH)
                             try:
                                 case_file = open(CASE_FILE_PATH,'r')

--- a/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
+++ b/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
@@ -214,6 +214,13 @@ do
                         printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
@@ -227,6 +234,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kSize$kernelSize.csv" "./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kSize""$kernelSize"".csv" ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
@@ -289,6 +304,13 @@ do
                         printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
@@ -302,6 +324,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kSize$kernelSize.csv" "./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kSize""$kernelSize"".csv" ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
@@ -364,6 +394,13 @@ do
                         printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
@@ -377,6 +414,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kSize$kernelSize.csv" "./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kSize""$kernelSize"".csv" ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 24 ]]
+                then
+                    for ((interpolationType=0;interpolationType<6;interpolationType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -74,6 +74,9 @@ int main(int argc, char **argv)
     case 2:
         strcpy(funcName, "blend");
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         break;
@@ -698,6 +701,64 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
             rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 6)
+            missingFuncFlag = 1;
+        else
+            missingFuncFlag = 1;
+
+        break;
+    }
+    case 24:
+    {
+        test_case_name = "warp_affine";
+
+        Rpp32f6 affineTensor_f6[images];
+        Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+        for (i = 0; i < images; i++)
+        {
+            affineTensor_f6[i].data[0] = 1.23;
+            affineTensor_f6[i].data[1] = 0.5;
+            affineTensor_f6[i].data[2] = 0;
+            affineTensor_f6[i].data[3] = -0.8;
+            affineTensor_f6[i].data[4] = 0.83;
+            affineTensor_f6[i].data[5] = 0;
+        }
+
+        // Uncomment to run test case with an xywhROI override
+        /*for (i = 0; i < images; i++)
+        {
+            roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+            roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+            roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+            roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+        }*/
+
+        // Uncomment to run test case with an ltrbROI override
+        /*for (i = 0; i < images; i++)
+            roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+            roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+            roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+            roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+        }
+        roiTypeSrc = RpptRoiType::LTRB;
+        roiTypeDst = RpptRoiType::LTRB;*/
+
+        hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+        start = clock();
+
+        if (ip_bitDepth == 0)
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 1)
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 2)
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 3)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 4)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 5)
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -21,6 +21,43 @@ using namespace std;
 #define RPPMAX2(a,b) ((a > b) ? a : b)
 #define RPPMIN2(a,b) ((a < b) ? a : b)
 
+std::string get_interpolation_type(unsigned int val, RpptInterpolationType &interpolationType)
+{
+    switch(val)
+    {
+        case 0:
+        {
+            interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
+            return "NearestNeighbor";
+        }
+        case 2:
+        {
+            interpolationType = RpptInterpolationType::BICUBIC;
+            return "Bicubic";
+        }
+        case 3:
+        {
+            interpolationType = RpptInterpolationType::LANCZOS;
+            return "Lanczos";
+        }
+        case 4:
+        {
+            interpolationType = RpptInterpolationType::TRIANGULAR;
+            return "Triangular";
+        }
+        case 5:
+        {
+            interpolationType = RpptInterpolationType::GAUSSIAN;
+            return "Gaussian";
+        }
+        default:
+        {
+            interpolationType = RpptInterpolationType::BILINEAR;
+            return "Bilinear";
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -40,10 +77,13 @@ int main(int argc, char **argv)
     int ip_bitDepth = atoi(argv[4]);
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
-    unsigned int verbosity = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[8]) : atoi(argv[7]);
-    unsigned int additionalParam = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[7]) : 1;
-    char additionalParam_char[2];
-    std::sprintf(additionalParam_char, "%u", additionalParam);
+
+    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
+    bool interpolationTypeCase = (test_case == 24);
+
+    unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
+    unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
 
     if (verbosity == 1)
     {
@@ -200,12 +240,25 @@ int main(int argc, char **argv)
     strcat(funcName, funcType);
     strcat(dst, "/");
     strcat(dst, funcName);
-    if (test_case == 40 || test_case == 41 || test_case == 49)
+
+    RpptInterpolationType interpolationType = RpptInterpolationType::BILINEAR;
+    if (kernelSizeCase)
     {
+        char additionalParam_char[2];
+        std::sprintf(additionalParam_char, "%u", additionalParam);
         strcat(func, "_kSize");
         strcat(func, additionalParam_char);
         strcat(dst, "_kSize");
         strcat(dst, additionalParam_char);
+    }
+    else if (interpolationTypeCase)
+    {
+        std::string interpolationTypeName;
+        interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
+        strcat(func, "_interpolationType");
+        strcat(func, interpolationTypeName.c_str());
+        strcat(dst, "_interpolationType");
+        strcat(dst, interpolationTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -712,6 +765,12 @@ int main(int argc, char **argv)
     {
         test_case_name = "warp_affine";
 
+        if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+        {
+            missingFuncFlag = 1;
+            break;
+        }
+
         Rpp32f6 affineTensor_f6[images];
         Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
         for (i = 0; i < images; i++)
@@ -748,17 +807,17 @@ int main(int argc, char **argv)
         start = clock();
 
         if (ip_bitDepth == 0)
-            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 1)
-            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 2)
-            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 3)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 4)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
-            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -83,6 +83,10 @@ int main(int argc, char **argv)
         strcpy(funcName, "blend");
         outputFormatToggle = 0;
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        outputFormatToggle = 0;
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         outputFormatToggle = 0;
@@ -706,6 +710,64 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
             rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 6)
+            missingFuncFlag = 1;
+        else
+            missingFuncFlag = 1;
+
+        break;
+    }
+    case 24:
+    {
+        test_case_name = "warp_affine";
+
+        Rpp32f6 affineTensor_f6[images];
+        Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+        for (i = 0; i < images; i++)
+        {
+            affineTensor_f6[i].data[0] = 1.23;
+            affineTensor_f6[i].data[1] = 0.5;
+            affineTensor_f6[i].data[2] = 0;
+            affineTensor_f6[i].data[3] = -0.8;
+            affineTensor_f6[i].data[4] = 0.83;
+            affineTensor_f6[i].data[5] = 0;
+        }
+
+        // Uncomment to run test case with an xywhROI override
+        /*for (i = 0; i < images; i++)
+        {
+            roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+            roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+            roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+            roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+        }*/
+
+        // Uncomment to run test case with an ltrbROI override
+        /*for (i = 0; i < images; i++)
+            roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+            roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+            roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+            roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+        }
+        roiTypeSrc = RpptRoiType::LTRB;
+        roiTypeDst = RpptRoiType::LTRB;*/
+
+        hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+        start = clock();
+
+        if (ip_bitDepth == 0)
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 1)
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 2)
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 3)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 4)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 5)
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -22,6 +22,43 @@ using namespace std;
 #define RPPMAX2(a,b) ((a > b) ? a : b)
 #define RPPMIN2(a,b) ((a < b) ? a : b)
 
+std::string get_interpolation_type(unsigned int val, RpptInterpolationType &interpolationType)
+{
+    switch(val)
+    {
+        case 0:
+        {
+            interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
+            return "NearestNeighbor";
+        }
+        case 2:
+        {
+            interpolationType = RpptInterpolationType::BICUBIC;
+            return "Bicubic";
+        }
+        case 3:
+        {
+            interpolationType = RpptInterpolationType::LANCZOS;
+            return "Lanczos";
+        }
+        case 4:
+        {
+            interpolationType = RpptInterpolationType::TRIANGULAR;
+            return "Triangular";
+        }
+        case 5:
+        {
+            interpolationType = RpptInterpolationType::GAUSSIAN;
+            return "Gaussian";
+        }
+        default:
+        {
+            interpolationType = RpptInterpolationType::BILINEAR;
+            return "Bilinear";
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -46,10 +83,13 @@ int main(int argc, char **argv)
     int ip_bitDepth = atoi(argv[4]);
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
-    unsigned int verbosity = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[8]) : atoi(argv[7]);
-    unsigned int additionalParam = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[7]) : 1;
-    char additionalParam_char[2];
-    std::sprintf(additionalParam_char, "%u", additionalParam);
+
+    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
+    bool interpolationTypeCase = (test_case == 24);
+
+    unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
+    unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
 
     if (verbosity == 1)
     {
@@ -208,12 +248,25 @@ int main(int argc, char **argv)
     strcat(funcName, funcType);
     strcat(dst, "/");
     strcat(dst, funcName);
-    if (test_case == 40 || test_case == 41 || test_case == 49)
+
+    RpptInterpolationType interpolationType = RpptInterpolationType::BILINEAR;
+    if (kernelSizeCase)
     {
+        char additionalParam_char[2];
+        std::sprintf(additionalParam_char, "%u", additionalParam);
         strcat(func, "_kSize");
         strcat(func, additionalParam_char);
         strcat(dst, "_kSize");
         strcat(dst, additionalParam_char);
+    }
+    else if (interpolationTypeCase)
+    {
+        std::string interpolationTypeName;
+        interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
+        strcat(func, "_interpolationType");
+        strcat(func, interpolationTypeName.c_str());
+        strcat(dst, "_interpolationType");
+        strcat(dst, interpolationTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -721,6 +774,12 @@ int main(int argc, char **argv)
     {
         test_case_name = "warp_affine";
 
+        if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+        {
+            missingFuncFlag = 1;
+            break;
+        }
+
         Rpp32f6 affineTensor_f6[images];
         Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
         for (i = 0; i < images; i++)
@@ -757,17 +816,17 @@ int main(int argc, char **argv)
         start = clock();
 
         if (ip_bitDepth == 0)
-            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 1)
-            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 2)
-            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 3)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 4)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
-            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -74,6 +74,9 @@ int main(int argc, char **argv)
     case 2:
         strcpy(funcName, "blend");
         break;
+    case 24:
+        strcpy(funcName, "warp_affine");
+        break;
     case 31:
         strcpy(funcName, "color_cast");
         break;
@@ -773,6 +776,64 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
             rppt_blend_gpu(d_inputi8, d_inputi8_second, srcDescPtr, d_outputi8, dstDescPtr, alpha, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 6)
+            missingFuncFlag = 1;
+        else
+            missingFuncFlag = 1;
+
+        break;
+    }
+    case 24:
+    {
+        test_case_name = "warp_affine";
+
+        Rpp32f6 affineTensor_f6[images];
+        Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
+        for (i = 0; i < images; i++)
+        {
+            affineTensor_f6[i].data[0] = 1.23;
+            affineTensor_f6[i].data[1] = 0.5;
+            affineTensor_f6[i].data[2] = 0;
+            affineTensor_f6[i].data[3] = -0.8;
+            affineTensor_f6[i].data[4] = 0.83;
+            affineTensor_f6[i].data[5] = 0;
+        }
+
+        // Uncomment to run test case with an xywhROI override
+        /*for (i = 0; i < images; i++)
+        {
+            roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+            roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+            roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+            roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+        }*/
+
+        // Uncomment to run test case with an ltrbROI override
+        /*for (i = 0; i < images; i++)
+            roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+            roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+            roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+            roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+        }
+        roiTypeSrc = RpptRoiType::LTRB;
+        roiTypeDst = RpptRoiType::LTRB;*/
+
+        hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+        start = clock();
+
+        if (ip_bitDepth == 0)
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 1)
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 2)
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+        else if (ip_bitDepth == 3)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 4)
+            missingFuncFlag = 1;
+        else if (ip_bitDepth == 5)
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -21,6 +21,43 @@ using namespace std;
 #define RPPMAX2(a,b) ((a > b) ? a : b)
 #define RPPMIN2(a,b) ((a < b) ? a : b)
 
+std::string get_interpolation_type(unsigned int val, RpptInterpolationType &interpolationType)
+{
+    switch(val)
+    {
+        case 0:
+        {
+            interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
+            return "NearestNeighbor";
+        }
+        case 2:
+        {
+            interpolationType = RpptInterpolationType::BICUBIC;
+            return "Bicubic";
+        }
+        case 3:
+        {
+            interpolationType = RpptInterpolationType::LANCZOS;
+            return "Lanczos";
+        }
+        case 4:
+        {
+            interpolationType = RpptInterpolationType::TRIANGULAR;
+            return "Triangular";
+        }
+        case 5:
+        {
+            interpolationType = RpptInterpolationType::GAUSSIAN;
+            return "Gaussian";
+        }
+        default:
+        {
+            interpolationType = RpptInterpolationType::BILINEAR;
+            return "Bilinear";
+        }
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -40,10 +77,13 @@ int main(int argc, char **argv)
     int ip_bitDepth = atoi(argv[4]);
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
-    unsigned int verbosity = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[8]) : atoi(argv[7]);
-    unsigned int additionalParam = (test_case == 40 || test_case == 41 || test_case == 49) ? atoi(argv[7]) : 1;
-    char additionalParam_char[2];
-    std::sprintf(additionalParam_char, "%u", additionalParam);
+
+    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
+    bool interpolationTypeCase = (test_case == 24);
+
+    unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
+    unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
 
     if (verbosity == 1)
     {
@@ -200,12 +240,25 @@ int main(int argc, char **argv)
     strcat(funcName, funcType);
     strcat(dst, "/");
     strcat(dst, funcName);
-    if (test_case == 40 || test_case == 41 || test_case == 49)
+
+    RpptInterpolationType interpolationType = RpptInterpolationType::BILINEAR;
+    if (kernelSizeCase)
     {
+        char additionalParam_char[2];
+        std::sprintf(additionalParam_char, "%u", additionalParam);
         strcat(func, "_kSize");
         strcat(func, additionalParam_char);
         strcat(dst, "_kSize");
         strcat(dst, additionalParam_char);
+    }
+    else if (interpolationTypeCase)
+    {
+        std::string interpolationTypeName;
+        interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
+        strcat(func, "_interpolationType");
+        strcat(func, interpolationTypeName.c_str());
+        strcat(dst, "_interpolationType");
+        strcat(dst, interpolationTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -787,6 +840,12 @@ int main(int argc, char **argv)
     {
         test_case_name = "warp_affine";
 
+        if ((interpolationType != RpptInterpolationType::BILINEAR) && (interpolationType != RpptInterpolationType::NEAREST_NEIGHBOR))
+        {
+            missingFuncFlag = 1;
+            break;
+        }
+
         Rpp32f6 affineTensor_f6[images];
         Rpp32f *affineTensor = (Rpp32f *)affineTensor_f6;
         for (i = 0; i < images; i++)
@@ -823,17 +882,17 @@ int main(int argc, char **argv)
         start = clock();
 
         if (ip_bitDepth == 0)
-            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_input, srcDescPtr, d_output, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 1)
-            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 2)
-            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 3)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 4)
             missingFuncFlag = 1;
         else if (ip_bitDepth == 5)
-            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, d_roiTensorPtrSrc, roiTypeSrc, handle);
+            rppt_warp_affine_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, affineTensor, interpolationType, d_roiTensorPtrSrc, roiTypeSrc, handle);
         else if (ip_bitDepth == 6)
             missingFuncFlag = 1;
         else

--- a/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
+++ b/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
@@ -212,6 +212,13 @@ do
                     printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                     ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0"
                 done
+            elif [[ "$case" -eq 24 ]]
+            then
+                for ((interpolationType=0;interpolationType<6;interpolationType++))
+                do
+                    printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                    ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
+                done
             else
                 printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
                 ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
@@ -281,6 +288,13 @@ do
                     printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                     ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0"
                 done
+            elif [[ "$case" -eq 24 ]]
+            then
+                for ((interpolationType=0;interpolationType<6;interpolationType++))
+                do
+                    printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                    ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
+                done
             else
                 printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
                 ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
@@ -349,6 +363,13 @@ do
                 do
                     printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
                     ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "0"
+                done
+            elif [[ "$case" -eq 24 ]]
+            then
+                for ((interpolationType=0;interpolationType<6;interpolationType++))
+                do
+                    printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                    ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
                 done
             else
                 printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"


### PR DESCRIPTION
- Adds support for warp affine tensor on hip.
- Support for U8/F32/F16/I8, NCHW/NHWC/toggle, Bilinear/NearestNeighbor is added.
- Adds corresponding unit tests and performance tests.