### PR TITLE
Salt and Pepper Noise Tensor implementation on host and hip

### DIFF
--- a/include/rppdefs.h
+++ b/include/rppdefs.h
@@ -292,6 +292,11 @@ typedef struct
     Rpp32u height;
 } RpptImagePatch, *RpptImagePatchPtr;
 
+typedef struct
+{   uint x[5];
+    uint counter;
+} RpptXorwowState;
+
 
 
 /******************** HOST memory typedefs ********************/

--- a/include/rppt_tensor_effects_augmentations.h
+++ b/include/rppt_tensor_effects_augmentations.h
@@ -67,6 +67,27 @@ RppStatus rppt_gridmask_host(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t d
 RppStatus rppt_spatter_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, RpptRGB spatterColor, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
 RppStatus rppt_spatter_host(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, RpptRGB spatterColor, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
 
+/******************** salt_and_pepper_noise ********************/
+
+// Salt and Pepper Noise augmentation for a NCHW/NHWC layout tensor
+
+// *param[in] srcPtr source tensor memory
+// *param[in] srcDesc source tensor descriptor
+// *param[out] dstPtr destination tensor memory
+// *param[in] dstDesc destination tensor descriptor
+// *param[in] noiseProbailityTensor noiseProbaility values to decide if a destination pixel is a noise-pixel, or equal to source (1D tensor of size batchSize with 0 <= noiseProbailityTensor[i] <= 1 for each image in batch)
+// *param[in] saltProbailityTensor saltProbaility values to decide if a given destination noise-pixel is salt or pepper (1D tensor of size batchSize with 0 <= saltProbailityTensor[i] <= 1 for each image in batch)
+// *param[in] saltValueTensor A user-defined salt noise value (1D tensor of size batchSize with 0 <= saltValueTensor[i] <= 1 for each image in batch)
+// *param[in] pepperValueTensor A user-defined pepper noise value (1D tensor of size batchSize with 0 <= pepperValueTensor[i] <= 1 for each image in batch)
+// *param[in] roiTensorSrc ROI data for each image in source tensor (2D tensor of size batchSize * 4, in either format - XYWH(xy.x, xy.y, roiWidth, roiHeight) or LTRB(lt.x, lt.y, rb.x, rb.y))
+// *param[in] roiType ROI type used (RpptRoiType::XYWH or RpptRoiType::LTRB)
+// *returns a  RppStatus enumeration.
+// *retval RPP_SUCCESS : succesful completion
+// *retval RPP_ERROR : Error
+
+RppStatus rppt_salt_and_pepper_noise_gpu(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, Rpp32f *noiseProbabilityTensor, Rpp32f *saltProbabilityTensor, Rpp32f *saltValueTensor, Rpp32f *pepperValueTensor, Rpp32u seed, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
+RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr, RpptDescPtr srcDescPtr, RppPtr_t dstPtr, RpptDescPtr dstDescPtr, Rpp32f *noiseProbabilityTensor, Rpp32f *saltProbabilityTensor, Rpp32f *saltValueTensor, Rpp32f *pepperValueTensor, Rpp32u seed, RpptROIPtr roiTensorPtrSrc, RpptRoiType roiType, rppHandle_t rppHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -42,7 +42,7 @@ static uint16_t wyhash16_x;
 
 alignas(64) const Rpp32f sch_mat[16] = {0.701f, -0.299f, -0.300f, 0.0f, -0.587f, 0.413f, -0.588f, 0.0f, -0.114f, -0.114f, 0.886f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 alignas(64) const Rpp32f ssh_mat[16] = {0.168f, -0.328f, 1.250f, 0.0f, 0.330f, 0.035f, -1.050f, 0.0f, -0.497f, 0.292f, -0.203f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
-alignas(64) const Rpp32u multiseedStreamOffset[8] = {1436021U, 2316707U, 4377697U, 1648039U, 1194659U, 2224457U, 3005987U, 2790331U};
+alignas(64) const Rpp32u multiseedStreamOffset[8] = {0x15E975, 0x2359A3, 0x42CC61, 0x1925A7, 0x123AA3, 0x21F149, 0x2DDE23, 0x2A93BB};    // Prime numbers for multiseed stream initialization
 
 inline uint32_t hash16(uint32_t input, uint32_t key) {
   uint32_t hash = input * key;
@@ -90,12 +90,12 @@ inline void rpp_host_rng_xorwow_f32_initialize_multiseed_stream(RpptXorwowState 
         xorwowSeedStream[i] = seed + multiseedStreamOffset[i];
     for (int i = 0; i < STREAM_SIZE; i++)
     {
-        xorwowInitialState[i].x[0] = 123456789U + xorwowSeedStream[i];
-        xorwowInitialState[i].x[1] = 362436069U + xorwowSeedStream[i];
-        xorwowInitialState[i].x[2] = 521288629U + xorwowSeedStream[i];
-        xorwowInitialState[i].x[3] = 88675123U + xorwowSeedStream[i];
-        xorwowInitialState[i].x[4] = 5783321U + xorwowSeedStream[i];
-        xorwowInitialState[i].counter = 6615241U + xorwowSeedStream[i];
+        xorwowInitialState[i].x[0] = 0x75BCD15 + xorwowSeedStream[i];
+        xorwowInitialState[i].x[1] = 0x159A55E5 + xorwowSeedStream[i];
+        xorwowInitialState[i].x[2] = 0x1F123BB5 + xorwowSeedStream[i];
+        xorwowInitialState[i].x[3] = 0x5491333 + xorwowSeedStream[i];
+        xorwowInitialState[i].x[4] = 0x583F19 + xorwowSeedStream[i];
+        xorwowInitialState[i].counter = 0x64F0C9 + xorwowSeedStream[i];
     }
 }
 

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -89,7 +89,7 @@ inline void rpp_host_rng_xorwow_f32_initialize_multiseed_stream(RpptXorwowState 
 {
     Rpp32u xorwowSeedStream[STREAM_SIZE];
 
-    // Loop to initialize STREAM_SIZE seed streams based on user seed and offset
+    // Loop to initialize seed stream of size STREAM_SIZE based on user seed and offset
     for (int i = 0; i < STREAM_SIZE; i++)
         xorwowSeedStream[i] = seed + multiseedStreamOffset[i];
 

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -120,7 +120,7 @@ inline __m256 rpp_host_rng_xorwow_8_f32_avx(__m256i *pxXorwowStateXParam, __m256
     __m256i px362437 = _mm256_set1_epi32(362437);
     __m256i pxFFFFFFFF = _mm256_set1_epi32(0xFFFFFFFF);
     __m256i px7FFFFF = _mm256_set1_epi32(0x7FFFFF);
-    __m256i pxExponentFloat = _mm256_set1_epi32(0b111111100000000000000000000000);
+    __m256i pxExponentFloat = _mm256_set1_epi32(0x3F800000);    // 0x3F800000 is Hex for 0b111111100000000000000000000000 - 23 bits of mantissa set to 0 and 01111111 for the exponent in IEEE float
     __m256i pxT = pxXorwowStateXParam[4];
     __m256i pxS = pxXorwowStateXParam[0];
     pxXorwowStateXParam[4] = pxXorwowStateXParam[3];
@@ -141,7 +141,7 @@ inline __m128 rpp_host_rng_xorwow_4_f32_sse(__m128i *pxXorwowStateXParam, __m128
     __m128i px362437 = _mm_set1_epi32(362437);
     __m128i pxFFFFFFFF = _mm_set1_epi32(0xFFFFFFFF);
     __m128i px7FFFFF = _mm_set1_epi32(0x7FFFFF);
-    __m128i pxExponentFloat = _mm_set1_epi32(0b111111100000000000000000000000);
+    __m128i pxExponentFloat = _mm_set1_epi32(0x3F800000);    // 0x3F800000 is Hex for 0b111111100000000000000000000000 - 23 bits of mantissa set to 0 and 01111111 for the exponent in IEEE float
     __m128i pxT = pxXorwowStateXParam[4];
     __m128i pxS = pxXorwowStateXParam[0];
     pxXorwowStateXParam[4] = pxXorwowStateXParam[3];
@@ -170,7 +170,7 @@ inline float rpp_host_rng_xorwow_f32(RpptXorwowState *xorwowState)
     t ^= s ^ (s << 4);
     xorwowState->x[0] = t;
     xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
-    uint out = (0b111111100000000000000000000000 | ((t + xorwowState->counter) & 0x7FFFFF));
+    uint out = (0x3F800000 | ((t + xorwowState->counter) & 0x7FFFFF));    // 0x3F800000 is Hex for 0b111111100000000000000000000000 - 23 bits of mantissa set to 0 and 01111111 for the exponent in IEEE float
     float outFloat = *(float *)&out;
     return  outFloat - 1;
 }

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -110,27 +110,27 @@ inline __m256 rpp_host_rng_xorwow_8_f32_avx(__m256i *pxXorwowStateXParam, __m256
     // Initialize avx-xorwow specific constants
     __m256i pxFFFFFFFF = _mm256_set1_epi32(0xFFFFFFFF);
     __m256i px7FFFFF = _mm256_set1_epi32(0x7FFFFF);
-    __m256i px362437 = _mm256_set1_epi32(XORWOW_COUNTER_INC);
+    __m256i pxXorwowCounterInc = _mm256_set1_epi32(XORWOW_COUNTER_INC);
     __m256i pxExponentFloat = _mm256_set1_epi32(XORWOW_EXPONENT_MASK);
 
     // Save current first and last x-params of xorwow state and compute pxT
-    __m256i pxT = pxXorwowStateXParam[0];                                                                                   // uint t  = xorwowState->x[0];
-    __m256i pxS = pxXorwowStateXParam[4];                                                                                   // uint s  = xorwowState->x[4];
-    pxT = _mm256_xor_si256(pxT, _mm256_srli_epi32(pxT, 2));                                                                 // t ^= t >> 2;
-    pxT = _mm256_xor_si256(pxT, _mm256_slli_epi32(pxT, 1));                                                                 // t ^= t << 1;
-    pxT = _mm256_xor_si256(pxT, _mm256_xor_si256(pxS, _mm256_slli_epi32(pxS, 4)));                                          // t ^= s ^ (s << 4);
+    __m256i pxT = pxXorwowStateXParam[0];                                                                                           // uint t  = xorwowState->x[0];
+    __m256i pxS = pxXorwowStateXParam[4];                                                                                           // uint s  = xorwowState->x[4];
+    pxT = _mm256_xor_si256(pxT, _mm256_srli_epi32(pxT, 2));                                                                         // t ^= t >> 2;
+    pxT = _mm256_xor_si256(pxT, _mm256_slli_epi32(pxT, 1));                                                                         // t ^= t << 1;
+    pxT = _mm256_xor_si256(pxT, _mm256_xor_si256(pxS, _mm256_slli_epi32(pxS, 4)));                                                  // t ^= s ^ (s << 4);
 
     // Update all 6 xorwow state params
-    pxXorwowStateXParam[0] = pxXorwowStateXParam[1];                                                                        // xorwowState->x[0] = xorwowState->x[1];
-    pxXorwowStateXParam[1] = pxXorwowStateXParam[2];                                                                        // xorwowState->x[1] = xorwowState->x[2];
-    pxXorwowStateXParam[2] = pxXorwowStateXParam[3];                                                                        // xorwowState->x[2] = xorwowState->x[3];
-    pxXorwowStateXParam[3] = pxXorwowStateXParam[4];                                                                        // xorwowState->x[3] = xorwowState->x[4];
-    pxXorwowStateXParam[4] = pxT;                                                                                           // xorwowState->x[4] = t;
-    *pxXorwowStateCounterParam = _mm256_and_si256(_mm256_add_epi32(*pxXorwowStateCounterParam, px362437), pxFFFFFFFF);      // xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
+    pxXorwowStateXParam[0] = pxXorwowStateXParam[1];                                                                                // xorwowState->x[0] = xorwowState->x[1];
+    pxXorwowStateXParam[1] = pxXorwowStateXParam[2];                                                                                // xorwowState->x[1] = xorwowState->x[2];
+    pxXorwowStateXParam[2] = pxXorwowStateXParam[3];                                                                                // xorwowState->x[2] = xorwowState->x[3];
+    pxXorwowStateXParam[3] = pxXorwowStateXParam[4];                                                                                // xorwowState->x[3] = xorwowState->x[4];
+    pxXorwowStateXParam[4] = pxT;                                                                                                   // xorwowState->x[4] = t;
+    *pxXorwowStateCounterParam = _mm256_and_si256(_mm256_add_epi32(*pxXorwowStateCounterParam, pxXorwowCounterInc), pxFFFFFFFF);    // xorwowState->counter = (xorwowState->counter + XORWOW_COUNTER_INC) & 0xFFFFFFFF;
 
     // Create float representation and return 0 <= pxS < 1
-    pxS = _mm256_or_si256(pxExponentFloat, _mm256_and_si256(_mm256_add_epi32(pxT, *pxXorwowStateCounterParam), px7FFFFF));  // uint out = (XORWOW_EXPONENT_MASK | ((t + xorwowState->counter) & 0x7FFFFF));
-    return _mm256_sub_ps(*(__m256 *)&pxS, avx_p1);                                                                          // return  *(float *)&out - 1;
+    pxS = _mm256_or_si256(pxExponentFloat, _mm256_and_si256(_mm256_add_epi32(pxT, *pxXorwowStateCounterParam), px7FFFFF));          // uint out = (XORWOW_EXPONENT_MASK | ((t + xorwowState->counter) & 0x7FFFFF));
+    return _mm256_sub_ps(*(__m256 *)&pxS, avx_p1);                                                                                  // return  *(float *)&out - 1;
 }
 
 inline __m128 rpp_host_rng_xorwow_4_f32_sse(__m128i *pxXorwowStateXParam, __m128i *pxXorwowStateCounterParam)
@@ -138,27 +138,27 @@ inline __m128 rpp_host_rng_xorwow_4_f32_sse(__m128i *pxXorwowStateXParam, __m128
     // Initialize sse-xorwow specific constants
     __m128i pxFFFFFFFF = _mm_set1_epi32(0xFFFFFFFF);
     __m128i px7FFFFF = _mm_set1_epi32(0x7FFFFF);
-    __m128i px362437 = _mm_set1_epi32(XORWOW_COUNTER_INC);
+    __m128i pxXorwowCounterInc = _mm_set1_epi32(XORWOW_COUNTER_INC);
     __m128i pxExponentFloat = _mm_set1_epi32(XORWOW_EXPONENT_MASK);
 
     // Save current first and last x-params of xorwow state and compute pxT
-    __m128i pxT = pxXorwowStateXParam[0];                                                                                   // uint t  = xorwowState->x[0];
-    __m128i pxS = pxXorwowStateXParam[4];                                                                                   // uint s  = xorwowState->x[4];
-    pxT = _mm_xor_si128(pxT, _mm_srli_epi32(pxT, 2));                                                                       // t ^= t >> 2;
-    pxT = _mm_xor_si128(pxT, _mm_slli_epi32(pxT, 1));                                                                       // t ^= t << 1;
-    pxT = _mm_xor_si128(pxT, _mm_xor_si128(pxS, _mm_slli_epi32(pxS, 4)));                                                   // t ^= s ^ (s << 4);
+    __m128i pxT = pxXorwowStateXParam[0];                                                                                           // uint t  = xorwowState->x[0];
+    __m128i pxS = pxXorwowStateXParam[4];                                                                                           // uint s  = xorwowState->x[4];
+    pxT = _mm_xor_si128(pxT, _mm_srli_epi32(pxT, 2));                                                                               // t ^= t >> 2;
+    pxT = _mm_xor_si128(pxT, _mm_slli_epi32(pxT, 1));                                                                               // t ^= t << 1;
+    pxT = _mm_xor_si128(pxT, _mm_xor_si128(pxS, _mm_slli_epi32(pxS, 4)));                                                           // t ^= s ^ (s << 4);
 
     // Update all 6 xorwow state params
-    pxXorwowStateXParam[0] = pxXorwowStateXParam[1];                                                                        // xorwowState->x[0] = xorwowState->x[1];
-    pxXorwowStateXParam[1] = pxXorwowStateXParam[2];                                                                        // xorwowState->x[1] = xorwowState->x[2];
-    pxXorwowStateXParam[2] = pxXorwowStateXParam[3];                                                                        // xorwowState->x[2] = xorwowState->x[3];
-    pxXorwowStateXParam[3] = pxXorwowStateXParam[4];                                                                        // xorwowState->x[3] = xorwowState->x[4];
-    pxXorwowStateXParam[4] = pxT;                                                                                           // xorwowState->x[4] = t;
-    *pxXorwowStateCounterParam = _mm_and_si128(_mm_add_epi32(*pxXorwowStateCounterParam, px362437), pxFFFFFFFF);            // xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
+    pxXorwowStateXParam[0] = pxXorwowStateXParam[1];                                                                                // xorwowState->x[0] = xorwowState->x[1];
+    pxXorwowStateXParam[1] = pxXorwowStateXParam[2];                                                                                // xorwowState->x[1] = xorwowState->x[2];
+    pxXorwowStateXParam[2] = pxXorwowStateXParam[3];                                                                                // xorwowState->x[2] = xorwowState->x[3];
+    pxXorwowStateXParam[3] = pxXorwowStateXParam[4];                                                                                // xorwowState->x[3] = xorwowState->x[4];
+    pxXorwowStateXParam[4] = pxT;                                                                                                   // xorwowState->x[4] = t;
+    *pxXorwowStateCounterParam = _mm_and_si128(_mm_add_epi32(*pxXorwowStateCounterParam, pxXorwowCounterInc), pxFFFFFFFF);          // xorwowState->counter = (xorwowState->counter + XORWOW_COUNTER_INC) & 0xFFFFFFFF;
 
     // Create float representation and return 0 <= pxS < 1
-    pxS = _mm_or_si128(pxExponentFloat, _mm_and_si128(_mm_add_epi32(pxT, *pxXorwowStateCounterParam), px7FFFFF));           // uint out = (XORWOW_EXPONENT_MASK | ((t + xorwowState->counter) & 0x7FFFFF));
-    return _mm_sub_ps(*(__m128 *)&pxS, xmm_p1);                                                                             // return  *(float *)&out - 1;
+    pxS = _mm_or_si128(pxExponentFloat, _mm_and_si128(_mm_add_epi32(pxT, *pxXorwowStateCounterParam), px7FFFFF));                   // uint out = (XORWOW_EXPONENT_MASK | ((t + xorwowState->counter) & 0x7FFFFF));
+    return _mm_sub_ps(*(__m128 *)&pxS, xmm_p1);                                                                                     // return  *(float *)&out - 1;
 }
 
 inline float rpp_host_rng_xorwow_f32(RpptXorwowState *xorwowState)

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -75,6 +75,24 @@ inline int fastrand()
     return (g_seed>>16)&0x7FFF;
 }
 
+inline float rpp_host_rng_xorwow_f32(RpptXorwowState *xorwowState)
+{
+    uint t  = xorwowState->x[4];
+    uint s  = xorwowState->x[0];
+    xorwowState->x[4] = xorwowState->x[3];
+    xorwowState->x[3] = xorwowState->x[2];
+    xorwowState->x[2] = xorwowState->x[1];
+    xorwowState->x[1] = s;
+    t ^= t >> 2;
+    t ^= t << 1;
+    t ^= s ^ (s << 4);
+    xorwowState->x[0] = t;
+    xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
+    uint out = (0b111111100000000000000000000000 | ((t + xorwowState->counter) & 0x7fffff));
+    float outFloat = *(float *)&out;
+    return  outFloat - 1;
+}
+
 inline int power_function(int a, int b)
 {
     int product = 1;

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1410,6 +1410,38 @@ __device__ __forceinline__ void rpp_hip_math_subtract24_const(d_float24 *src_f24
     dst_f24->f4[5] = src_f24->f4[5] - subtrahend_f4;
 }
 
+// /******************** DEVICE RANDOMIZATION HELPER FUNCTIONS ********************/
+
+__device__ __forceinline__ float rpp_hip_rng_xorwow_f32(RpptXorwowState *xorwowState)
+{
+    uint t  = xorwowState->x[4];
+    uint s  = xorwowState->x[0];
+    xorwowState->x[4] = xorwowState->x[3];
+    xorwowState->x[3] = xorwowState->x[2];
+    xorwowState->x[2] = xorwowState->x[1];
+    xorwowState->x[1] = s;
+    t ^= t >> 2;
+    t ^= t << 1;
+    t ^= s ^ (s << 4);
+    xorwowState->x[0] = t;
+    xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
+    uint out = (0b111111100000000000000000000000 | ((t + xorwowState->counter) & 0x7fffff));
+    float outFloat = *(float *)&out;
+    return  outFloat - 1;
+}
+
+__device__ __forceinline__ void rpp_hip_rng_8_xorwow_f32(RpptXorwowState *xorwowState, d_float8 *randomNumbersPtr_f8)
+{
+    randomNumbersPtr_f8->f1[0] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[1] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[2] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[3] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[4] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[5] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[6] = rpp_hip_rng_xorwow_f32(xorwowState);
+    randomNumbersPtr_f8->f1[7] = rpp_hip_rng_xorwow_f32(xorwowState);
+}
+
 // /******************** DEVICE INTERPOLATION HELPER FUNCTIONS ********************/
 
 // BILINEAR INTERPOLATION LOAD HELPERS (separate load routines for each bit depth)

--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -1425,7 +1425,7 @@ __device__ __forceinline__ float rpp_hip_rng_xorwow_f32(RpptXorwowState *xorwowS
     t ^= s ^ (s << 4);
     xorwowState->x[0] = t;
     xorwowState->counter = (xorwowState->counter + 362437) & 0xFFFFFFFF;
-    uint out = (0b111111100000000000000000000000 | ((t + xorwowState->counter) & 0x7fffff));
+    uint out = (0x3F800000 | ((t + xorwowState->counter) & 0x7fffff));    // 0x3F800000 is Hex for 0b111111100000000000000000000000 - 23 bits of mantissa set to 0 and 01111111 for the exponent
     float outFloat = *(float *)&out;
     return  outFloat - 1;
 }

--- a/src/modules/cpu/host_tensor_effects_augmentations.hpp
+++ b/src/modules/cpu/host_tensor_effects_augmentations.hpp
@@ -25,5 +25,6 @@ THE SOFTWARE.
 
 #include "kernel/gridmask.hpp"
 #include "kernel/spatter.hpp"
+#include "kernel/noise_salt_and_pepper.hpp"
 
 #endif // HOST_TENSOR_EFFECTS_AUGMENTATIONS_HPP

--- a/src/modules/cpu/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/cpu/kernel/noise_salt_and_pepper.hpp
@@ -1,0 +1,1087 @@
+#include "rppdefs.h"
+#include "cpu/rpp_cpu_simd.hpp"
+#include "cpu/rpp_cpu_common.hpp"
+
+RppStatus salt_and_pepper_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
+                                                  RpptDescPtr srcDescPtr,
+                                                  Rpp8u *dstPtr,
+                                                  RpptDescPtr dstDescPtr,
+                                                  Rpp32f *noiseProbabilityTensor,
+                                                  Rpp32f *saltProbabilityTensor,
+                                                  Rpp32f *saltValueTensor,
+                                                  Rpp32f *pepperValueTensor,
+                                                  RpptXorwowState *xorwowInitialStatePtr,
+                                                  RpptROIPtr roiTensorPtrSrc,
+                                                  RpptRoiType roiType,
+                                                  RppLayoutParams layoutParams)
+{
+    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+
+    omp_set_dynamic(0);
+#pragma omp parallel for num_threads(dstDescPtr->n)
+    for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
+    {
+        RpptROI roi;
+        RpptROIPtr roiPtrInput = &roiTensorPtrSrc[batchCount];
+        compute_roi_validation_host(roiPtrInput, &roi, &roiDefault, roiType);
+
+        Rpp32f noiseProbability = noiseProbabilityTensor[batchCount];
+        Rpp32f saltProbability = saltProbabilityTensor[batchCount] * noiseProbability;
+        Rpp8u salt = (Rpp8u) (saltValueTensor[batchCount] * 255.0f);
+        Rpp8u pepper = (Rpp8u) (pepperValueTensor[batchCount] * 255.0f);
+        RpptXorwowState xorwowState;
+        Rpp32u offset = batchCount * srcDescPtr->strides.nStride;
+        xorwowState.x[0] = xorwowInitialStatePtr->x[0] + offset;
+        xorwowState.x[1] = xorwowInitialStatePtr->x[1] + offset;
+        xorwowState.x[2] = xorwowInitialStatePtr->x[2] + offset;
+        xorwowState.x[3] = xorwowInitialStatePtr->x[3] + offset;
+        xorwowState.x[4] = xorwowInitialStatePtr->x[4] + offset;
+        xorwowState.counter = xorwowInitialStatePtr->counter + offset;
+
+        Rpp8u *srcPtrImage, *dstPtrImage;
+        srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
+        dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
+
+        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
+
+        Rpp8u *srcPtrChannel, *dstPtrChannel;
+        srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
+        dstPtrChannel = dstPtrImage;
+
+        // Salt and Pepper Noise with fused output-layout toggle (NHWC -> NCHW)
+        if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8u *srcPtrRow, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8u *srcPtrTemp, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    Rpp8u dst[3];
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dst, srcPtrTemp, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dst, salt, 3);
+                        else
+                            memset(dst, pepper, 3);
+                    *dstPtrTempR = dst[0];
+                    *dstPtrTempG = dst[1];
+                    *dstPtrTempB = dst[2];
+
+                    srcPtrTemp+=3;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise with fused output-layout toggle (NCHW -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8u *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTemp;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    Rpp8u src[3] = {*srcPtrTempR, *srcPtrTempG, *srcPtrTempB};
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, src, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dstPtrTemp, salt, 3);
+                        else
+                            memset(dstPtrTemp, pepper, 3);
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NHWC -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp8u *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8u *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, srcPtrTemp, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dstPtrTemp, salt, 3);
+                        else
+                            memset(dstPtrTemp, pepper, 3);
+
+                    srcPtrTemp += 3;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8u *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                    {
+                        *dstPtrTempR = *srcPtrTempR;
+                        *dstPtrTempG = *srcPtrTempG;
+                        *dstPtrTempB = *srcPtrTempB;
+                    }
+                    else
+                    {
+                        if(randomNumberFloat <= saltProbability)
+                        {
+                            *dstPtrTempR = salt;
+                            *dstPtrTempG = salt;
+                            *dstPtrTempB = salt;
+                        }
+                        else
+                        {
+                            *dstPtrTempR = pepper;
+                            *dstPtrTempG = pepper;
+                            *dstPtrTempB = pepper;
+                        }
+                    }
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle single channel (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 1) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8u *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8u *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        *dstPtrTemp = *srcPtrTemp;
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            *dstPtrTemp = salt;
+                        else
+                            *dstPtrTemp = pepper;
+
+                    srcPtrTemp++;
+                    dstPtrTemp++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+    }
+
+    return RPP_SUCCESS;
+}
+
+RppStatus salt_and_pepper_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
+                                                    RpptDescPtr srcDescPtr,
+                                                    Rpp32f *dstPtr,
+                                                    RpptDescPtr dstDescPtr,
+                                                    Rpp32f *noiseProbabilityTensor,
+                                                    Rpp32f *saltProbabilityTensor,
+                                                    Rpp32f *saltValueTensor,
+                                                    Rpp32f *pepperValueTensor,
+                                                    RpptXorwowState *xorwowInitialStatePtr,
+                                                    RpptROIPtr roiTensorPtrSrc,
+                                                    RpptRoiType roiType,
+                                                    RppLayoutParams layoutParams)
+{
+    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+
+    omp_set_dynamic(0);
+#pragma omp parallel for num_threads(dstDescPtr->n)
+    for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
+    {
+        RpptROI roi;
+        RpptROIPtr roiPtrInput = &roiTensorPtrSrc[batchCount];
+        compute_roi_validation_host(roiPtrInput, &roi, &roiDefault, roiType);
+
+        Rpp32f noiseProbability = noiseProbabilityTensor[batchCount];
+        Rpp32f saltProbability = saltProbabilityTensor[batchCount] * noiseProbability;
+        Rpp32f salt = saltValueTensor[batchCount];
+        Rpp32f pepper = pepperValueTensor[batchCount];
+        RpptXorwowState xorwowState;
+        Rpp32u offset = batchCount * srcDescPtr->strides.nStride;
+        xorwowState.x[0] = xorwowInitialStatePtr->x[0] + offset;
+        xorwowState.x[1] = xorwowInitialStatePtr->x[1] + offset;
+        xorwowState.x[2] = xorwowInitialStatePtr->x[2] + offset;
+        xorwowState.x[3] = xorwowInitialStatePtr->x[3] + offset;
+        xorwowState.x[4] = xorwowInitialStatePtr->x[4] + offset;
+        xorwowState.counter = xorwowInitialStatePtr->counter + offset;
+
+        Rpp32f *srcPtrImage, *dstPtrImage;
+        srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
+        dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
+
+        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
+
+        Rpp32f *srcPtrChannel, *dstPtrChannel;
+        srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
+        dstPtrChannel = dstPtrImage;
+
+        // Salt and Pepper Noise with fused output-layout toggle (NHWC -> NCHW)
+        if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp32f *srcPtrRow, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp32f *srcPtrTemp, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    Rpp32f dst[3];
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dst, srcPtrTemp, 12);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dst, 3, salt);
+                        else
+                            std::fill_n(dst, 3, pepper);
+                    *dstPtrTempR = dst[0];
+                    *dstPtrTempG = dst[1];
+                    *dstPtrTempB = dst[2];
+
+                    srcPtrTemp += 3;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise with fused output-layout toggle (NCHW -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp32f *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp32f *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTemp;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    Rpp32f src[3] = {*srcPtrTempR, *srcPtrTempG, *srcPtrTempB};
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, src, 12);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dstPtrTemp, 3, salt);
+                        else
+                            std::fill_n(dstPtrTemp, 3, pepper);
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NHWC -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp32f *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp32f *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, srcPtrTemp, 12);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dstPtrTemp, 3, salt);
+                        else
+                            std::fill_n(dstPtrTemp, 3, pepper);
+
+                    srcPtrTemp += 3;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp32f *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp32f *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                    {
+                        *dstPtrTempR = *srcPtrTempR;
+                        *dstPtrTempG = *srcPtrTempG;
+                        *dstPtrTempB = *srcPtrTempB;
+                    }
+                    else
+                    {
+                        if(randomNumberFloat <= saltProbability)
+                        {
+                            *dstPtrTempR = salt;
+                            *dstPtrTempG = salt;
+                            *dstPtrTempB = salt;
+                        }
+                        else
+                        {
+                            *dstPtrTempR = pepper;
+                            *dstPtrTempG = pepper;
+                            *dstPtrTempB = pepper;
+                        }
+                    }
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRowR += srcDescPtr->strides.hStride;
+                dstPtrRowG += srcDescPtr->strides.hStride;
+                dstPtrRowB += srcDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle single channel (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 1) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp32f *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp32f *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        *dstPtrTemp = *srcPtrTemp;
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            *dstPtrTemp = salt;
+                        else
+                            *dstPtrTemp = pepper;
+
+                    srcPtrTemp++;
+                    dstPtrTemp++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+    }
+
+    return RPP_SUCCESS;
+}
+
+RppStatus salt_and_pepper_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
+                                                    RpptDescPtr srcDescPtr,
+                                                    Rpp16f *dstPtr,
+                                                    RpptDescPtr dstDescPtr,
+                                                    Rpp32f *noiseProbabilityTensor,
+                                                    Rpp32f *saltProbabilityTensor,
+                                                    Rpp32f *saltValueTensor,
+                                                    Rpp32f *pepperValueTensor,
+                                                    RpptXorwowState *xorwowInitialStatePtr,
+                                                    RpptROIPtr roiTensorPtrSrc,
+                                                    RpptRoiType roiType,
+                                                    RppLayoutParams layoutParams)
+{
+    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+
+    omp_set_dynamic(0);
+#pragma omp parallel for num_threads(dstDescPtr->n)
+    for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
+    {
+        RpptROI roi;
+        RpptROIPtr roiPtrInput = &roiTensorPtrSrc[batchCount];
+        compute_roi_validation_host(roiPtrInput, &roi, &roiDefault, roiType);
+
+        Rpp32f noiseProbability = noiseProbabilityTensor[batchCount];
+        Rpp32f saltProbability = saltProbabilityTensor[batchCount] * noiseProbability;
+        Rpp16f salt = (Rpp16f) saltValueTensor[batchCount];
+        Rpp16f pepper = (Rpp16f) pepperValueTensor[batchCount];
+        RpptXorwowState xorwowState;
+        Rpp32u offset = batchCount * srcDescPtr->strides.nStride;
+        xorwowState.x[0] = xorwowInitialStatePtr->x[0] + offset;
+        xorwowState.x[1] = xorwowInitialStatePtr->x[1] + offset;
+        xorwowState.x[2] = xorwowInitialStatePtr->x[2] + offset;
+        xorwowState.x[3] = xorwowInitialStatePtr->x[3] + offset;
+        xorwowState.x[4] = xorwowInitialStatePtr->x[4] + offset;
+        xorwowState.counter = xorwowInitialStatePtr->counter + offset;
+
+        Rpp16f *srcPtrImage, *dstPtrImage;
+        srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
+        dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
+
+        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
+
+        Rpp16f *srcPtrChannel, *dstPtrChannel;
+        srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
+        dstPtrChannel = dstPtrImage;
+
+        // Salt and Pepper Noise with fused output-layout toggle (NHWC -> NCHW)
+        if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp16f *srcPtrRow, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp16f *srcPtrTemp, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    Rpp16f dst[3];
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dst, srcPtrTemp, 6);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dst, 3, salt);
+                        else
+                            std::fill_n(dst, 3, pepper);
+                    *dstPtrTempR = dst[0];
+                    *dstPtrTempG = dst[1];
+                    *dstPtrTempB = dst[2];
+
+                    srcPtrTemp += 3;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise with fused output-layout toggle (NCHW -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp16f *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp16f *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTemp;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    Rpp16f src[3] = {*srcPtrTempR, *srcPtrTempG, *srcPtrTempB};
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, src, 6);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dstPtrTemp, 3, salt);
+                        else
+                            std::fill_n(dstPtrTemp, 3, pepper);
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NHWC -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp16f *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp16f *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, srcPtrTemp, 6);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            std::fill_n(dstPtrTemp, 3, salt);
+                        else
+                            std::fill_n(dstPtrTemp, 3, pepper);
+
+                    srcPtrTemp += 3;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp16f *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp16f *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                    {
+                        *dstPtrTempR = *srcPtrTempR;
+                        *dstPtrTempG = *srcPtrTempG;
+                        *dstPtrTempB = *srcPtrTempB;
+                    }
+                    else
+                    {
+                        if(randomNumberFloat <= saltProbability)
+                        {
+                            *dstPtrTempR = salt;
+                            *dstPtrTempG = salt;
+                            *dstPtrTempB = salt;
+                        }
+                        else
+                        {
+                            *dstPtrTempR = pepper;
+                            *dstPtrTempG = pepper;
+                            *dstPtrTempB = pepper;
+                        }
+                    }
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRowR += srcDescPtr->strides.hStride;
+                dstPtrRowG += srcDescPtr->strides.hStride;
+                dstPtrRowB += srcDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle single channel (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 1) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp16f *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp16f *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        *dstPtrTemp = *srcPtrTemp;
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            *dstPtrTemp = salt;
+                        else
+                            *dstPtrTemp = pepper;
+
+                    srcPtrTemp++;
+                    dstPtrTemp++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+    }
+
+    return RPP_SUCCESS;
+}
+
+RppStatus salt_and_pepper_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
+                                                  RpptDescPtr srcDescPtr,
+                                                  Rpp8s *dstPtr,
+                                                  RpptDescPtr dstDescPtr,
+                                                  Rpp32f *noiseProbabilityTensor,
+                                                  Rpp32f *saltProbabilityTensor,
+                                                  Rpp32f *saltValueTensor,
+                                                  Rpp32f *pepperValueTensor,
+                                                  RpptXorwowState *xorwowInitialStatePtr,
+                                                  RpptROIPtr roiTensorPtrSrc,
+                                                  RpptRoiType roiType,
+                                                  RppLayoutParams layoutParams)
+{
+    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+
+    omp_set_dynamic(0);
+#pragma omp parallel for num_threads(dstDescPtr->n)
+    for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
+    {
+        RpptROI roi;
+        RpptROIPtr roiPtrInput = &roiTensorPtrSrc[batchCount];
+        compute_roi_validation_host(roiPtrInput, &roi, &roiDefault, roiType);
+
+        Rpp32f noiseProbability = noiseProbabilityTensor[batchCount];
+        Rpp32f saltProbability = saltProbabilityTensor[batchCount] * noiseProbability;
+        Rpp8s salt = (Rpp8s) ((saltValueTensor[batchCount] * 255.0f) - 128.0f);
+        Rpp8s pepper = (Rpp8s) ((pepperValueTensor[batchCount] * 255.0f) - 128.0f);
+        RpptXorwowState xorwowState;
+        Rpp32u offset = batchCount * srcDescPtr->strides.nStride;
+        xorwowState.x[0] = xorwowInitialStatePtr->x[0] + offset;
+        xorwowState.x[1] = xorwowInitialStatePtr->x[1] + offset;
+        xorwowState.x[2] = xorwowInitialStatePtr->x[2] + offset;
+        xorwowState.x[3] = xorwowInitialStatePtr->x[3] + offset;
+        xorwowState.x[4] = xorwowInitialStatePtr->x[4] + offset;
+        xorwowState.counter = xorwowInitialStatePtr->counter + offset;
+
+        Rpp8s *srcPtrImage, *dstPtrImage;
+        srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
+        dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
+
+        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
+
+        Rpp8s *srcPtrChannel, *dstPtrChannel;
+        srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
+        dstPtrChannel = dstPtrImage;
+
+        // Salt and Pepper Noise with fused output-layout toggle (NHWC -> NCHW)
+        if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8s *srcPtrRow, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8s *srcPtrTemp, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    Rpp8s dst[3];
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dst, srcPtrTemp, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dst, salt, 3);
+                        else
+                            memset(dst, pepper, 3);
+                    *dstPtrTempR = dst[0];
+                    *dstPtrTempG = dst[1];
+                    *dstPtrTempB = dst[2];
+
+                    srcPtrTemp+=3;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise with fused output-layout toggle (NCHW -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8s *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTemp;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    Rpp8s src[3] = {*srcPtrTempR, *srcPtrTempG, *srcPtrTempB};
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, src, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dstPtrTemp, salt, 3);
+                        else
+                            memset(dstPtrTemp, pepper, 3);
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NHWC -> NHWC)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            Rpp8s *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8s *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        memcpy(dstPtrTemp, srcPtrTemp, 3);
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            memset(dstPtrTemp, salt, 3);
+                        else
+                            memset(dstPtrTemp, pepper, 3);
+
+                    srcPtrTemp += 3;
+                    dstPtrTemp += 3;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRowR, *dstPtrRowG, *dstPtrRowB;
+            srcPtrRowR = srcPtrChannel;
+            srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
+            srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
+            dstPtrRowR = dstPtrChannel;
+            dstPtrRowG = dstPtrRowR + dstDescPtr->strides.cStride;
+            dstPtrRowB = dstPtrRowG + dstDescPtr->strides.cStride;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8s *srcPtrTempR, *srcPtrTempG, *srcPtrTempB, *dstPtrTempR, *dstPtrTempG, *dstPtrTempB;
+                srcPtrTempR = srcPtrRowR;
+                srcPtrTempG = srcPtrRowG;
+                srcPtrTempB = srcPtrRowB;
+                dstPtrTempR = dstPtrRowR;
+                dstPtrTempG = dstPtrRowG;
+                dstPtrTempB = dstPtrRowB;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                    {
+                        *dstPtrTempR = *srcPtrTempR;
+                        *dstPtrTempG = *srcPtrTempG;
+                        *dstPtrTempB = *srcPtrTempB;
+                    }
+                    else
+                    {
+                        if(randomNumberFloat <= saltProbability)
+                        {
+                            *dstPtrTempR = salt;
+                            *dstPtrTempG = salt;
+                            *dstPtrTempB = salt;
+                        }
+                        else
+                        {
+                            *dstPtrTempR = pepper;
+                            *dstPtrTempG = pepper;
+                            *dstPtrTempB = pepper;
+                        }
+                    }
+
+                    srcPtrTempR++;
+                    srcPtrTempG++;
+                    srcPtrTempB++;
+                    dstPtrTempR++;
+                    dstPtrTempG++;
+                    dstPtrTempB++;
+                }
+
+                srcPtrRowR += srcDescPtr->strides.hStride;
+                srcPtrRowG += srcDescPtr->strides.hStride;
+                srcPtrRowB += srcDescPtr->strides.hStride;
+                dstPtrRowR += dstDescPtr->strides.hStride;
+                dstPtrRowG += dstDescPtr->strides.hStride;
+                dstPtrRowB += dstDescPtr->strides.hStride;
+            }
+        }
+
+        // Salt and Pepper Noise without fused output-layout toggle single channel (NCHW -> NCHW)
+        else if ((srcDescPtr->c == 1) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            Rpp8s *srcPtrRow, *dstPtrRow;
+            srcPtrRow = srcPtrChannel;
+            dstPtrRow = dstPtrChannel;
+
+            for(int i = 0; i < roi.xywhROI.roiHeight; i++)
+            {
+                Rpp8s *srcPtrTemp, *dstPtrTemp;
+                srcPtrTemp = srcPtrRow;
+                dstPtrTemp = dstPtrRow;
+
+                int vectorLoopCount = 0;
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    float randomNumberFloat = rpp_host_rng_xorwow_f32(&xorwowState);
+                    if (randomNumberFloat > noiseProbability)
+                        *dstPtrTemp = *srcPtrTemp;
+                    else
+                        if(randomNumberFloat <= saltProbability)
+                            *dstPtrTemp = salt;
+                        else
+                            *dstPtrTemp = pepper;
+
+                    srcPtrTemp++;
+                    dstPtrTemp++;
+                }
+
+                srcPtrRow += srcDescPtr->strides.hStride;
+                dstPtrRow += dstDescPtr->strides.hStride;
+            }
+        }
+    }
+
+    return RPP_SUCCESS;
+}

--- a/src/modules/hip/hip_tensor_effects_augmentations.hpp
+++ b/src/modules/hip/hip_tensor_effects_augmentations.hpp
@@ -25,5 +25,6 @@ THE SOFTWARE.
 
 #include "kernel/gridmask.hpp"
 #include "kernel/spatter.hpp"
+#include "kernel/noise_salt_and_pepper.hpp"
 
 #endif // HIP_TENSOR_EFFECTS_AUGMENTATIONS_HPP

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -1,0 +1,436 @@
+#include <hip/hip_runtime.h>
+#include "hip/rpp_hip_common.hpp"
+
+__device__ void salt_and_pepper_noise_1_hip_compute(float *src, float *dst, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
+{
+    if (randomNumberFloat > noiseProbability)
+        *dst = *src;
+    else
+        *dst = ((randomNumberFloat <= saltProbability) ? salt : pepper);
+}
+
+__device__ void salt_and_pepper_noise_3_hip_compute(float3 *src_f3, float3 *dst_f3, float noiseProbability, float saltProbability, float3 salt_f3, float3 pepper_f3, RpptXorwowState *xorwowStatePtr)
+{
+    float randomNumberFloat = rpp_hip_rng_xorwow_f32(xorwowStatePtr);
+    if (randomNumberFloat > noiseProbability)
+        *dst_f3 = *src_f3;
+    else
+        *dst_f3 = ((randomNumberFloat <= saltProbability) ? salt_f3 : pepper_f3);
+}
+
+__device__ void salt_and_pepper_noise_8_hip_compute(d_float8 *src_f8, d_float8 *dst_f8, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
+{
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[0], &dst_f8->f1[0], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[1], &dst_f8->f1[1], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[2], &dst_f8->f1[2], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[3], &dst_f8->f1[3], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[4], &dst_f8->f1[4], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[5], &dst_f8->f1[5], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[6], &dst_f8->f1[6], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
+    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[7], &dst_f8->f1[7], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
+}
+
+__device__ void salt_and_pepper_noise_24_hip_compute(d_float24 *src_f24, d_float24 *dst_f24, float noiseProbability, float saltProbability, float3 salt_f3, float3 pepper_f3, RpptXorwowState *xorwowStatePtr)
+{
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[0], &dst_f24->f3[0], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[1], &dst_f24->f3[1], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[2], &dst_f24->f3[2], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[3], &dst_f24->f3[3], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[4], &dst_f24->f3[4], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[5], &dst_f24->f3[5], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[6], &dst_f24->f3[6], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f3[7], &dst_f24->f3[7], noiseProbability, saltProbability, salt_f3, pepper_f3, xorwowStatePtr);
+}
+
+__device__ void salt_and_pepper_noise_adjusted_input_hip_compute(uchar *srcPtr, float *saltValue, float *pepperValue) { *saltValue *= 255.0f; *pepperValue *= 255.0f; }
+__device__ void salt_and_pepper_noise_adjusted_input_hip_compute(float *srcPtr, float *saltValue, float *pepperValue) {}
+__device__ void salt_and_pepper_noise_adjusted_input_hip_compute(schar *srcPtr, float *saltValue, float *pepperValue) { *saltValue = (*saltValue * 255.0f) - 128.0f; *pepperValue = (*pepperValue * 255.0f) - 128.0f; }
+__device__ void salt_and_pepper_noise_adjusted_input_hip_compute(half *srcPtr, float *saltValue, float *pepperValue) {}
+
+template <typename T>
+__global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
+                                                 uint2 srcStridesNH,
+                                                 T *dstPtr,
+                                                 uint2 dstStridesNH,
+                                                 float *noiseProbabilityTensor,
+                                                 float *saltProbabilityTensor,
+                                                 float *saltValueTensor,
+                                                 float *pepperValueTensor,
+                                                 RpptXorwowState *xorwowInitialStatePtr,
+                                                 RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= roiTensorPtrSrc[id_z].xywhROI.roiHeight) || (id_x >= roiTensorPtrSrc[id_z].xywhROI.roiWidth))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x) + ((id_y + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    float noiseProbability = noiseProbabilityTensor[id_z];
+    float saltProbability = saltProbabilityTensor[id_z] * noiseProbability;
+    float saltValue = saltValueTensor[id_z];
+    float pepperValue = pepperValueTensor[id_z];
+    RpptXorwowState xorwowState;
+    xorwowState.x[0] = xorwowInitialStatePtr->x[0] + srcIdx;
+    xorwowState.x[1] = xorwowInitialStatePtr->x[1] + srcIdx;
+    xorwowState.x[2] = xorwowInitialStatePtr->x[2] + srcIdx;
+    xorwowState.x[3] = xorwowInitialStatePtr->x[3] + srcIdx;
+    xorwowState.x[4] = xorwowInitialStatePtr->x[4] + srcIdx;
+    xorwowState.counter = xorwowInitialStatePtr->counter + srcIdx;
+
+
+    // Method 1
+
+    // d_float24 src_f24, dst_f24;
+
+    // rpp_hip_load24_pkd3_and_unpack_to_float24_pkd3(srcPtr + srcIdx, &src_f24);
+    // salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    // salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, (float3)saltValue, (float3)pepperValue, &xorwowState);
+    // rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+
+
+
+    // Method 2
+
+    d_float8 randomNumbers_f8;
+    d_float24 src_f24, dst_f24;
+
+    rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
+    salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+}
+
+template <typename T>
+__global__ void salt_and_pepper_noise_pln_tensor(T *srcPtr,
+                                                 uint3 srcStridesNCH,
+                                                 T *dstPtr,
+                                                 uint3 dstStridesNCH,
+                                                 int channelsDst,
+                                                 float *noiseProbabilityTensor,
+                                                 float *saltProbabilityTensor,
+                                                 float *saltValueTensor,
+                                                 float *pepperValueTensor,
+                                                 RpptXorwowState *xorwowInitialStatePtr,
+                                                 RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= roiTensorPtrSrc[id_z].xywhROI.roiHeight) || (id_x >= roiTensorPtrSrc[id_z].xywhROI.roiWidth))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x) + ((id_y + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x + roiTensorPtrSrc[id_z].xywhROI.xy.x);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    float noiseProbability = noiseProbabilityTensor[id_z];
+    float saltProbability = saltProbabilityTensor[id_z] * noiseProbability;
+    float saltValue = saltValueTensor[id_z];
+    float pepperValue = pepperValueTensor[id_z];
+    RpptXorwowState xorwowState;
+    xorwowState.x[0] = xorwowInitialStatePtr->x[0] + srcIdx;
+    xorwowState.x[1] = xorwowInitialStatePtr->x[1] + srcIdx;
+    xorwowState.x[2] = xorwowInitialStatePtr->x[2] + srcIdx;
+    xorwowState.x[3] = xorwowInitialStatePtr->x[3] + srcIdx;
+    xorwowState.x[4] = xorwowInitialStatePtr->x[4] + srcIdx;
+    xorwowState.counter = xorwowInitialStatePtr->counter + srcIdx;
+
+    d_float8 src_f8, dst_f8, randomNumbers_f8;
+    rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
+    salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+
+    rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+
+    if (channelsDst == 3)
+    {
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
+        salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+
+        srcIdx += srcStridesNCH.y;
+        dstIdx += dstStridesNCH.y;
+
+        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
+        salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+    }
+}
+
+template <typename T>
+__global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
+                                                       uint2 srcStridesNH,
+                                                       T *dstPtr,
+                                                       uint3 dstStridesNCH,
+                                                       float *noiseProbabilityTensor,
+                                                       float *saltProbabilityTensor,
+                                                       float *saltValueTensor,
+                                                       float *pepperValueTensor,
+                                                       RpptXorwowState *xorwowInitialStatePtr,
+                                                       RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= roiTensorPtrSrc[id_z].xywhROI.roiHeight) || (id_x >= roiTensorPtrSrc[id_z].xywhROI.roiWidth))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNH.x) + ((id_y + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
+    uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
+
+    float noiseProbability = noiseProbabilityTensor[id_z];
+    float saltProbability = saltProbabilityTensor[id_z] * noiseProbability;
+    float saltValue = saltValueTensor[id_z];
+    float pepperValue = pepperValueTensor[id_z];
+    RpptXorwowState xorwowState;
+    xorwowState.x[0] = xorwowInitialStatePtr->x[0] + srcIdx;
+    xorwowState.x[1] = xorwowInitialStatePtr->x[1] + srcIdx;
+    xorwowState.x[2] = xorwowInitialStatePtr->x[2] + srcIdx;
+    xorwowState.x[3] = xorwowInitialStatePtr->x[3] + srcIdx;
+    xorwowState.x[4] = xorwowInitialStatePtr->x[4] + srcIdx;
+    xorwowState.counter = xorwowInitialStatePtr->counter + srcIdx;
+
+    // Method 1
+
+    // d_float24 src_f24, dst_f24;
+
+    // rpp_hip_load24_pkd3_and_unpack_to_float24_pkd3(srcPtr + srcIdx, &src_f24);
+    // salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    // salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, (float3)saltValue, (float3)pepperValue, &xorwowState);
+    // rpp_hip_pack_float24_pkd3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &dst_f24);
+
+
+
+    // Method 2
+
+    d_float8 randomNumbers_f8;
+    d_float24 src_f24, dst_f24;
+
+    rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
+    salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &dst_f24);
+}
+
+template <typename T>
+__global__ void salt_and_pepper_noise_pln3_pkd3_tensor(T *srcPtr,
+                                                       uint3 srcStridesNCH,
+                                                       T *dstPtr,
+                                                       uint2 dstStridesNH,
+                                                       float *noiseProbabilityTensor,
+                                                       float *saltProbabilityTensor,
+                                                       float *saltValueTensor,
+                                                       float *pepperValueTensor,
+                                                       RpptXorwowState *xorwowInitialStatePtr,
+                                                       RpptROIPtr roiTensorPtrSrc)
+{
+    int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+
+    if ((id_y >= roiTensorPtrSrc[id_z].xywhROI.roiHeight) || (id_x >= roiTensorPtrSrc[id_z].xywhROI.roiWidth))
+    {
+        return;
+    }
+
+    uint srcIdx = (id_z * srcStridesNCH.x) + ((id_y + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x + roiTensorPtrSrc[id_z].xywhROI.xy.x);
+    uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
+
+    float noiseProbability = noiseProbabilityTensor[id_z];
+    float saltProbability = saltProbabilityTensor[id_z] * noiseProbability;
+    float saltValue = saltValueTensor[id_z];
+    float pepperValue = pepperValueTensor[id_z];
+    RpptXorwowState xorwowState;
+    xorwowState.x[0] = xorwowInitialStatePtr->x[0] + srcIdx;
+    xorwowState.x[1] = xorwowInitialStatePtr->x[1] + srcIdx;
+    xorwowState.x[2] = xorwowInitialStatePtr->x[2] + srcIdx;
+    xorwowState.x[3] = xorwowInitialStatePtr->x[3] + srcIdx;
+    xorwowState.x[4] = xorwowInitialStatePtr->x[4] + srcIdx;
+    xorwowState.counter = xorwowInitialStatePtr->counter + srcIdx;
+
+
+
+    // Method 1
+
+    // d_float24 src_f24, dst_f24;
+
+    // rpp_hip_load24_pln3_and_unpack_to_float24_pkd3(srcPtr + srcIdx, srcStridesNCH.y, &src_f24);
+    // salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    // salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, (float3)saltValue, (float3)pepperValue, &xorwowState);
+    // rpp_hip_pack_float24_pkd3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+
+
+
+
+    // Method 2
+
+    d_float8 randomNumbers_f8;
+    d_float24 src_f24, dst_f24;
+
+    rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
+    salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
+    rpp_hip_load24_pln3_and_unpack_to_float24_pln3(srcPtr + srcIdx, srcStridesNCH.y, &src_f24);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+}
+
+template <typename T>
+RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
+                                                RpptDescPtr srcDescPtr,
+                                                T *dstPtr,
+                                                RpptDescPtr dstDescPtr,
+                                                RpptXorwowState *xorwowInitialStatePtr,
+                                                RpptROIPtr roiTensorPtrSrc,
+                                                RpptRoiType roiType,
+                                                rpp::Handle& handle)
+{
+    if (roiType == RpptRoiType::LTRB)
+        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+
+    int localThreads_x = LOCAL_THREADS_X;
+    int localThreads_y = LOCAL_THREADS_Y;
+    int localThreads_z = LOCAL_THREADS_Z;
+    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_y = dstDescPtr->h;
+    int globalThreads_z = handle.GetBatchSize();
+
+    // d_xorwow_state xorwowState;
+    // d_xorwow_state *xorwowStatePtr;
+    // xorwowStatePtr = &xorwowState;
+    // *xorwowStatePtr = xorwowInitialState;
+    // for (int i = 0; i < 10; i++)
+    // {
+    //     uint randomNumber = rpp_hip_rng_xorwow(&xorwowState);
+    // }
+
+    // d_xorwow_state_s xorwowState, xorwowStateFloat;
+    // xorwowState.x[0] = 123456789U;
+    // xorwowState.x[1] = 362436069U;
+    // xorwowState.x[2] = 521288629U;
+    // xorwowState.x[3] = 88675123U;
+    // xorwowState.x[4] = 5783321U;
+    // xorwowState.counter = 6615241U;
+    // xorwowStateFloat = xorwowState;
+    // // xorwowStateFloat.x[0] = 123456789U;
+    // // xorwowStateFloat.x[1] = 0;
+    // // xorwowStateFloat.x[2] = 0;
+    // // xorwowStateFloat.x[3] = 0;
+    // // xorwowStateFloat.x[4] = 0;
+    // // xorwowStateFloat.counter = 0;
+    // for (int i = 0; i < 10; i++)
+    // {
+    //     uint randomNumber = rpp_hip_rng_xorwow(&xorwowState);
+    //     float randomNumberFloat = rpp_hip_rng_xorwow_f32(&xorwowStateFloat);
+    //     printf("\n %d, %f", randomNumber, randomNumberFloat);
+    // }
+
+
+    // hipMemcpy(dstPtr, srcPtr, dstDescPtr->n * dstDescPtr->strides.nStride * sizeof(float), hipMemcpyDeviceToDevice);
+    // std::random_device rd;  // Random number engine seed
+    // std::mt19937 gen(rd()); // Seeding rd() to fast mersenne twister engine
+    // std::uniform_real_distribution<> mt19937Distrib(0, 1);
+
+    if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+    {
+        globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
+        hipLaunchKernelGGL(salt_and_pepper_noise_pkd_tensor,
+                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                           dim3(localThreads_x, localThreads_y, localThreads_z),
+                           0,
+                           handle.GetStream(),
+                           srcPtr,
+                           make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                           dstPtr,
+                           make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                           handle.GetInitHandle()->mem.mgpu.floatArr[0].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[1].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[2].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[3].floatmem,
+                           xorwowInitialStatePtr,
+                           roiTensorPtrSrc);
+    }
+    else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
+    {
+        hipLaunchKernelGGL(salt_and_pepper_noise_pln_tensor,
+                           dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                           dim3(localThreads_x, localThreads_y, localThreads_z),
+                           0,
+                           handle.GetStream(),
+                           srcPtr,
+                           make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                           dstPtr,
+                           make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                           dstDescPtr->c,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[0].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[1].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[2].floatmem,
+                           handle.GetInitHandle()->mem.mgpu.floatArr[3].floatmem,
+                           xorwowInitialStatePtr,
+                           roiTensorPtrSrc);
+    }
+    else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
+    {
+        if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
+        {
+            hipLaunchKernelGGL(salt_and_pepper_noise_pkd3_pln3_tensor,
+                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                               dim3(localThreads_x, localThreads_y, localThreads_z),
+                               0,
+                               handle.GetStream(),
+                               srcPtr,
+                               make_uint2(srcDescPtr->strides.nStride, srcDescPtr->strides.hStride),
+                               dstPtr,
+                               make_uint3(dstDescPtr->strides.nStride, dstDescPtr->strides.cStride, dstDescPtr->strides.hStride),
+                               handle.GetInitHandle()->mem.mgpu.floatArr[0].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[1].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[2].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[3].floatmem,
+                               xorwowInitialStatePtr,
+                               roiTensorPtrSrc);
+        }
+        else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
+        {
+            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
+            hipLaunchKernelGGL(salt_and_pepper_noise_pln3_pkd3_tensor,
+                               dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                               dim3(localThreads_x, localThreads_y, localThreads_z),
+                               0,
+                               handle.GetStream(),
+                               srcPtr,
+                               make_uint3(srcDescPtr->strides.nStride, srcDescPtr->strides.cStride, srcDescPtr->strides.hStride),
+                               dstPtr,
+                               make_uint2(dstDescPtr->strides.nStride, dstDescPtr->strides.hStride),
+                               handle.GetInitHandle()->mem.mgpu.floatArr[0].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[1].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[2].floatmem,
+                               handle.GetInitHandle()->mem.mgpu.floatArr[3].floatmem,
+                               xorwowInitialStatePtr,
+                               roiTensorPtrSrc);
+        }
+    }
+
+    return RPP_SUCCESS;
+}

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -22,6 +22,32 @@ __device__ void salt_and_pepper_noise_8_hip_compute(d_float8 *src_f8, d_float8 *
     salt_and_pepper_noise_1_hip_compute(&src_f8->f1[7], &dst_f8->f1[7], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
 }
 
+__device__ void salt_and_pepper_noise_3_hip_compute(float *srcR, float *dstR, float *srcG, float *dstG, float *srcB, float *dstB, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
+{
+    if (randomNumberFloat > noiseProbability)
+    {
+        *dstR = *srcR;
+        *dstG = *srcG;
+        *dstB = *srcB;
+    }
+    else
+    {
+        *dstR = *dstG = *dstB = ((randomNumberFloat <= saltProbability) ? salt : pepper);
+    }
+}
+
+__device__ void salt_and_pepper_noise_24_hip_compute(d_float24 *src_f24, d_float24 *dst_f24, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
+{
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[0], &dst_f24->f1[0], &src_f24->f1[ 8], &dst_f24->f1[ 8], &src_f24->f1[16], &dst_f24->f1[16], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[1], &dst_f24->f1[1], &src_f24->f1[ 9], &dst_f24->f1[ 9], &src_f24->f1[17], &dst_f24->f1[17], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[2], &dst_f24->f1[2], &src_f24->f1[10], &dst_f24->f1[10], &src_f24->f1[18], &dst_f24->f1[18], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[3], &dst_f24->f1[3], &src_f24->f1[11], &dst_f24->f1[11], &src_f24->f1[19], &dst_f24->f1[19], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[4], &dst_f24->f1[4], &src_f24->f1[12], &dst_f24->f1[12], &src_f24->f1[20], &dst_f24->f1[20], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[5], &dst_f24->f1[5], &src_f24->f1[13], &dst_f24->f1[13], &src_f24->f1[21], &dst_f24->f1[21], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[6], &dst_f24->f1[6], &src_f24->f1[14], &dst_f24->f1[14], &src_f24->f1[22], &dst_f24->f1[22], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
+    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[7], &dst_f24->f1[7], &src_f24->f1[15], &dst_f24->f1[15], &src_f24->f1[23], &dst_f24->f1[23], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
+}
+
 __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(uchar *srcPtr, float *saltValue, float *pepperValue) { *saltValue *= 255.0f; *pepperValue *= 255.0f; }
 __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(float *srcPtr, float *saltValue, float *pepperValue) {}
 __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(schar *srcPtr, float *saltValue, float *pepperValue) { *saltValue = (*saltValue * 255.0f) - 128.0f; *pepperValue = (*pepperValue * 255.0f) - 128.0f; }
@@ -73,9 +99,7 @@ __global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
     rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
     rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
 }
 
@@ -192,9 +216,7 @@ __global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
     rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
     rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &dst_f24);
 }
 
@@ -244,9 +266,7 @@ __global__ void salt_and_pepper_noise_pln3_pkd3_tensor(T *srcPtr,
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
     rpp_hip_load24_pln3_and_unpack_to_float24_pln3(srcPtr + srcIdx, srcStridesNCH.y, &src_f24);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[0], &dst_f24.f8[0], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[1], &dst_f24.f8[1], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f24.f8[2], &dst_f24.f8[2], noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
     rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
 }
 

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -272,7 +272,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
 
     Rpp32u *xorwowSeedStream;
     xorwowSeedStream = (Rpp32u *)&xorwowInitialStatePtr[1];
-    hipMemcpy(xorwowSeedStream, rngSeedStream1036800, 1036800 * sizeof(Rpp32u), hipMemcpyHostToDevice);
+    hipMemcpy(xorwowSeedStream, rngSeedStream1036800, SEED_STREAM_MAX_SIZE * sizeof(Rpp32u), hipMemcpyHostToDevice);
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -75,7 +75,7 @@ __global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
     float pepperValue = pepperValueTensor[id_z];
 
     RpptXorwowState xorwowState;
-    uint xorwowSeed = (seedStreamIdx >= SEED_STREAM_MAX_SIZE) ? xorwowSeedStream[seedStreamIdx - SEED_STREAM_MAX_SIZE] : xorwowSeedStream[seedStreamIdx];
+    uint xorwowSeed = xorwowSeedStream[seedStreamIdx % SEED_STREAM_MAX_SIZE];
     xorwowState.x[0] = xorwowInitialStatePtr->x[0] + xorwowSeed;
     xorwowState.x[1] = xorwowInitialStatePtr->x[1] + xorwowSeed;
     xorwowState.x[2] = xorwowInitialStatePtr->x[2] + xorwowSeed;
@@ -126,7 +126,7 @@ __global__ void salt_and_pepper_noise_pln_tensor(T *srcPtr,
     float pepperValue = pepperValueTensor[id_z];
 
     RpptXorwowState xorwowState;
-    uint xorwowSeed = (seedStreamIdx >= SEED_STREAM_MAX_SIZE) ? xorwowSeedStream[seedStreamIdx - SEED_STREAM_MAX_SIZE] : xorwowSeedStream[seedStreamIdx];
+    uint xorwowSeed = xorwowSeedStream[seedStreamIdx % SEED_STREAM_MAX_SIZE];
     xorwowState.x[0] = xorwowInitialStatePtr->x[0] + xorwowSeed;
     xorwowState.x[1] = xorwowInitialStatePtr->x[1] + xorwowSeed;
     xorwowState.x[2] = xorwowInitialStatePtr->x[2] + xorwowSeed;
@@ -192,7 +192,7 @@ __global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
     float pepperValue = pepperValueTensor[id_z];
 
     RpptXorwowState xorwowState;
-    uint xorwowSeed = (seedStreamIdx >= SEED_STREAM_MAX_SIZE) ? xorwowSeedStream[seedStreamIdx - SEED_STREAM_MAX_SIZE] : xorwowSeedStream[seedStreamIdx];
+    uint xorwowSeed = xorwowSeedStream[seedStreamIdx % SEED_STREAM_MAX_SIZE];
     xorwowState.x[0] = xorwowInitialStatePtr->x[0] + xorwowSeed;
     xorwowState.x[1] = xorwowInitialStatePtr->x[1] + xorwowSeed;
     xorwowState.x[2] = xorwowInitialStatePtr->x[2] + xorwowSeed;
@@ -242,7 +242,7 @@ __global__ void salt_and_pepper_noise_pln3_pkd3_tensor(T *srcPtr,
     float pepperValue = pepperValueTensor[id_z];
 
     RpptXorwowState xorwowState;
-    uint xorwowSeed = (seedStreamIdx >= SEED_STREAM_MAX_SIZE) ? xorwowSeedStream[seedStreamIdx - SEED_STREAM_MAX_SIZE] : xorwowSeedStream[seedStreamIdx];
+    uint xorwowSeed = xorwowSeedStream[seedStreamIdx % SEED_STREAM_MAX_SIZE];
     xorwowState.x[0] = xorwowInitialStatePtr->x[0] + xorwowSeed;
     xorwowState.x[1] = xorwowInitialStatePtr->x[1] + xorwowSeed;
     xorwowState.x[2] = xorwowInitialStatePtr->x[2] + xorwowSeed;
@@ -282,7 +282,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
 
     Rpp32u *xorwowSeedStream;
     xorwowSeedStream = (Rpp32u *)&xorwowInitialStatePtr[1];
-    hipMemcpy(xorwowSeedStream, rngSeedStream1036800, SEED_STREAM_MAX_SIZE * sizeof(Rpp32u), hipMemcpyHostToDevice);
+    hipMemcpy(xorwowSeedStream, rngSeedStream4050, SEED_STREAM_MAX_SIZE * sizeof(Rpp32u), hipMemcpyHostToDevice);
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -2,50 +2,40 @@
 #include "hip/rpp_hip_common.hpp"
 #include "func_specific/rng_seed_stream.hpp"
 
-__device__ void salt_and_pepper_noise_1_hip_compute(float *src, float *dst, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
+__device__ void salt_and_pepper_noise_1_hip_compute(float *pix, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
 {
-    if (randomNumberFloat > noiseProbability)
-        *dst = *src;
-    else
-        *dst = ((randomNumberFloat <= saltProbability) ? salt : pepper);
+    if (randomNumberFloat <= noiseProbability)
+        *pix = (randomNumberFloat <= saltProbability) ? salt : pepper;
 }
 
-__device__ void salt_and_pepper_noise_8_hip_compute(d_float8 *src_f8, d_float8 *dst_f8, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
+__device__ void salt_and_pepper_noise_8_hip_compute(d_float8 *pix_f8, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
 {
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[0], &dst_f8->f1[0], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[1], &dst_f8->f1[1], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[2], &dst_f8->f1[2], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[3], &dst_f8->f1[3], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[4], &dst_f8->f1[4], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[5], &dst_f8->f1[5], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[6], &dst_f8->f1[6], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
-    salt_and_pepper_noise_1_hip_compute(&src_f8->f1[7], &dst_f8->f1[7], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[0], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[1], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[2], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[3], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[4], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[5], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[6], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
+    salt_and_pepper_noise_1_hip_compute(&pix_f8->f1[7], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
 }
 
-__device__ void salt_and_pepper_noise_3_hip_compute(float *srcR, float *dstR, float *srcG, float *dstG, float *srcB, float *dstB, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
+__device__ void salt_and_pepper_noise_3_hip_compute(float *pixR, float *pixG, float *pixB, float noiseProbability, float saltProbability, float salt, float pepper, float randomNumberFloat)
 {
-    if (randomNumberFloat > noiseProbability)
-    {
-        *dstR = *srcR;
-        *dstG = *srcG;
-        *dstB = *srcB;
-    }
-    else
-    {
-        *dstR = *dstG = *dstB = ((randomNumberFloat <= saltProbability) ? salt : pepper);
-    }
+    if (randomNumberFloat <= noiseProbability)
+        *pixR = *pixG = *pixB = (randomNumberFloat <= saltProbability) ? salt : pepper;
 }
 
-__device__ void salt_and_pepper_noise_24_hip_compute(d_float24 *src_f24, d_float24 *dst_f24, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
+__device__ void salt_and_pepper_noise_24_hip_compute(d_float24 *pix_f24, float noiseProbability, float saltProbability, float salt, float pepper, d_float8 *randomNumbers_f8)
 {
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[0], &dst_f24->f1[0], &src_f24->f1[ 8], &dst_f24->f1[ 8], &src_f24->f1[16], &dst_f24->f1[16], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[1], &dst_f24->f1[1], &src_f24->f1[ 9], &dst_f24->f1[ 9], &src_f24->f1[17], &dst_f24->f1[17], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[2], &dst_f24->f1[2], &src_f24->f1[10], &dst_f24->f1[10], &src_f24->f1[18], &dst_f24->f1[18], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[3], &dst_f24->f1[3], &src_f24->f1[11], &dst_f24->f1[11], &src_f24->f1[19], &dst_f24->f1[19], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[4], &dst_f24->f1[4], &src_f24->f1[12], &dst_f24->f1[12], &src_f24->f1[20], &dst_f24->f1[20], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[5], &dst_f24->f1[5], &src_f24->f1[13], &dst_f24->f1[13], &src_f24->f1[21], &dst_f24->f1[21], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[6], &dst_f24->f1[6], &src_f24->f1[14], &dst_f24->f1[14], &src_f24->f1[22], &dst_f24->f1[22], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
-    salt_and_pepper_noise_3_hip_compute(&src_f24->f1[7], &dst_f24->f1[7], &src_f24->f1[15], &dst_f24->f1[15], &src_f24->f1[23], &dst_f24->f1[23], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[0], &pix_f24->f1[ 8], &pix_f24->f1[16], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[0]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[1], &pix_f24->f1[ 9], &pix_f24->f1[17], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[1]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[2], &pix_f24->f1[10], &pix_f24->f1[18], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[2]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[3], &pix_f24->f1[11], &pix_f24->f1[19], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[3]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[4], &pix_f24->f1[12], &pix_f24->f1[20], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[4]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[5], &pix_f24->f1[13], &pix_f24->f1[21], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[5]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[6], &pix_f24->f1[14], &pix_f24->f1[22], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[6]);
+    salt_and_pepper_noise_3_hip_compute(&pix_f24->f1[7], &pix_f24->f1[15], &pix_f24->f1[23], noiseProbability, saltProbability, salt, pepper, randomNumbers_f8->f1[7]);
 }
 
 __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(uchar *srcPtr, float *saltValue, float *pepperValue) { *saltValue *= 255.0f; *pepperValue *= 255.0f; }
@@ -94,13 +84,13 @@ __global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
     xorwowState.counter = xorwowInitialStatePtr->counter + xorwowSeed;
 
     d_float8 randomNumbers_f8;
-    d_float24 src_f24, dst_f24;
+    d_float24 pix_f24;
 
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
-    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
-    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &pix_f24);
+    salt_and_pepper_noise_24_hip_compute(&pix_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &pix_f24);
 }
 
 template <typename T>
@@ -144,29 +134,29 @@ __global__ void salt_and_pepper_noise_pln_tensor(T *srcPtr,
     xorwowState.x[4] = xorwowInitialStatePtr->x[4] + xorwowSeed;
     xorwowState.counter = xorwowInitialStatePtr->counter + xorwowSeed;
 
-    d_float8 src_f8, dst_f8, randomNumbers_f8;
+    d_float8 pix_f8, randomNumbers_f8;
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
 
-    rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
-    salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+    rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &pix_f8);
+    salt_and_pepper_noise_8_hip_compute(&pix_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &pix_f8);
 
     if (channelsDst == 3)
     {
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
-        salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &pix_f8);
+        salt_and_pepper_noise_8_hip_compute(&pix_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &pix_f8);
 
         srcIdx += srcStridesNCH.y;
         dstIdx += dstStridesNCH.y;
 
-        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &src_f8);
-        salt_and_pepper_noise_8_hip_compute(&src_f8, &dst_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &dst_f8);
+        rpp_hip_load8_and_unpack_to_float8(srcPtr + srcIdx, &pix_f8);
+        salt_and_pepper_noise_8_hip_compute(&pix_f8, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+        rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &pix_f8);
     }
 }
 
@@ -211,13 +201,13 @@ __global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
     xorwowState.counter = xorwowInitialStatePtr->counter + xorwowSeed;
 
     d_float8 randomNumbers_f8;
-    d_float24 src_f24, dst_f24;
+    d_float24 pix_f24;
 
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
-    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &src_f24);
-    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &dst_f24);
+    rpp_hip_load24_pkd3_and_unpack_to_float24_pln3(srcPtr + srcIdx, &pix_f24);
+    salt_and_pepper_noise_24_hip_compute(&pix_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &pix_f24);
 }
 
 template <typename T>
@@ -261,13 +251,13 @@ __global__ void salt_and_pepper_noise_pln3_pkd3_tensor(T *srcPtr,
     xorwowState.counter = xorwowInitialStatePtr->counter + xorwowSeed;
 
     d_float8 randomNumbers_f8;
-    d_float24 src_f24, dst_f24;
+    d_float24 pix_f24;
 
     rpp_hip_rng_8_xorwow_f32(&xorwowState, &randomNumbers_f8);
     salt_and_pepper_noise_adjusted_input_hip_compute(srcPtr, &saltValue, &pepperValue);
-    rpp_hip_load24_pln3_and_unpack_to_float24_pln3(srcPtr + srcIdx, srcStridesNCH.y, &src_f24);
-    salt_and_pepper_noise_24_hip_compute(&src_f24, &dst_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
-    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &dst_f24);
+    rpp_hip_load24_pln3_and_unpack_to_float24_pln3(srcPtr + srcIdx, srcStridesNCH.y, &pix_f24);
+    salt_and_pepper_noise_24_hip_compute(&pix_f24, noiseProbability, saltProbability, saltValue, pepperValue, &randomNumbers_f8);
+    rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &pix_f24);
 }
 
 template <typename T>

--- a/src/modules/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/rppt_tensor_effects_augmentations.cpp
@@ -458,13 +458,8 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
             return RPP_ERROR_INVALID_ARGUMENTS;
 
     RppLayoutParams layoutParams = get_layout_params(srcDescPtr->layout, srcDescPtr->c);
-    RpptXorwowState xorwowInitialState;
-    xorwowInitialState.x[0] = 123456789U + seed;
-    xorwowInitialState.x[1] = 362436069U + seed;
-    xorwowInitialState.x[2] = 521288629U + seed;
-    xorwowInitialState.x[3] = 88675123U + seed;
-    xorwowInitialState.x[4] = 5783321U + seed;
-    xorwowInitialState.counter = 6615241U + seed;
+    RpptXorwowState xorwowInitialState[4];
+    rpp_host_rng_xorwow_f32_initialize(xorwowInitialState, seed);
 
     if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
     {
@@ -476,7 +471,7 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
                                                 saltProbabilityTensor,
                                                 saltValueTensor,
                                                 pepperValueTensor,
-                                                &xorwowInitialState,
+                                                xorwowInitialState,
                                                 roiTensorPtrSrc,
                                                 roiType,
                                                 layoutParams);
@@ -491,7 +486,7 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
                                                   saltProbabilityTensor,
                                                   saltValueTensor,
                                                   pepperValueTensor,
-                                                  &xorwowInitialState,
+                                                  xorwowInitialState,
                                                   roiTensorPtrSrc,
                                                   roiType,
                                                   layoutParams);
@@ -506,7 +501,7 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
                                                   saltProbabilityTensor,
                                                   saltValueTensor,
                                                   pepperValueTensor,
-                                                  &xorwowInitialState,
+                                                  xorwowInitialState,
                                                   roiTensorPtrSrc,
                                                   roiType,
                                                   layoutParams);
@@ -521,7 +516,7 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
                                                 saltProbabilityTensor,
                                                 saltValueTensor,
                                                 pepperValueTensor,
-                                                &xorwowInitialState,
+                                                xorwowInitialState,
                                                 roiTensorPtrSrc,
                                                 roiType,
                                                 layoutParams);

--- a/src/modules/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/rppt_tensor_effects_augmentations.cpp
@@ -350,3 +350,182 @@ RppStatus rppt_spatter_host(RppPtr_t srcPtr,
 
     return RPP_SUCCESS;
 }
+
+/******************** salt_and_pepper_noise ********************/
+
+RppStatus rppt_salt_and_pepper_noise_gpu(RppPtr_t srcPtr,
+                                         RpptDescPtr srcDescPtr,
+                                         RppPtr_t dstPtr,
+                                         RpptDescPtr dstDescPtr,
+                                         Rpp32f *noiseProbabilityTensor,
+                                         Rpp32f *saltProbabilityTensor,
+                                         Rpp32f *saltValueTensor,
+                                         Rpp32f *pepperValueTensor,
+                                         Rpp32u seed,
+                                         RpptROIPtr roiTensorPtrSrc,
+                                         RpptRoiType roiType,
+                                         rppHandle_t rppHandle)
+{
+#ifdef HIP_COMPILE
+    for(int i = 0; i < srcDescPtr->n; i++)
+        if (!RPPINRANGE(noiseProbabilityTensor[i], 0, 1) || !RPPINRANGE(saltProbabilityTensor[i], 0, 1) || !RPPINRANGE(saltValueTensor[i], 0, 1) || !RPPINRANGE(pepperValueTensor[i], 0, 1))
+            return RPP_ERROR_INVALID_ARGUMENTS;
+
+    Rpp32u paramIndex = 0;
+    copy_param_float(noiseProbabilityTensor, rpp::deref(rppHandle), paramIndex++);
+    copy_param_float(saltProbabilityTensor, rpp::deref(rppHandle), paramIndex++);
+    copy_param_float(saltValueTensor, rpp::deref(rppHandle), paramIndex++);
+    copy_param_float(pepperValueTensor, rpp::deref(rppHandle), paramIndex++);
+
+    RpptXorwowState xorwowInitialState;
+    xorwowInitialState.x[0] = 123456789U + seed;
+    xorwowInitialState.x[1] = 362436069U + seed;
+    xorwowInitialState.x[2] = 521288629U + seed;
+    xorwowInitialState.x[3] = 88675123U + seed;
+    xorwowInitialState.x[4] = 5783321U + seed;
+    xorwowInitialState.counter = 6615241U + seed;
+
+    RpptXorwowState *d_xorwowInitialStatePtr;
+    d_xorwowInitialStatePtr = (RpptXorwowState *) rpp::deref(rppHandle).GetInitHandle()->mem.mgpu.maskArr.floatmem;
+    hipMemcpy(d_xorwowInitialStatePtr, &xorwowInitialState, sizeof(RpptXorwowState), hipMemcpyHostToDevice);
+
+    if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
+    {
+        hip_exec_salt_and_pepper_noise_tensor(static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                              srcDescPtr,
+                                              static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                              dstDescPtr,
+                                              d_xorwowInitialStatePtr,
+                                              roiTensorPtrSrc,
+                                              roiType,
+                                              rpp::deref(rppHandle));
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
+    {
+        hip_exec_salt_and_pepper_noise_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                              srcDescPtr,
+                                              (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                              dstDescPtr,
+                                              d_xorwowInitialStatePtr,
+                                              roiTensorPtrSrc,
+                                              roiType,
+                                              rpp::deref(rppHandle));
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
+    {
+        hip_exec_salt_and_pepper_noise_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                              srcDescPtr,
+                                              (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                              dstDescPtr,
+                                              d_xorwowInitialStatePtr,
+                                              roiTensorPtrSrc,
+                                              roiType,
+                                              rpp::deref(rppHandle));
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
+    {
+        hip_exec_salt_and_pepper_noise_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                              srcDescPtr,
+                                              static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                              dstDescPtr,
+                                              d_xorwowInitialStatePtr,
+                                              roiTensorPtrSrc,
+                                              roiType,
+                                              rpp::deref(rppHandle));
+    }
+
+    return RPP_SUCCESS;
+#elif defined(OCL_COMPILE)
+    return RPP_ERROR_NOT_IMPLEMENTED;
+#endif // backend
+}
+
+RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
+                                          RpptDescPtr srcDescPtr,
+                                          RppPtr_t dstPtr,
+                                          RpptDescPtr dstDescPtr,
+                                          Rpp32f *noiseProbabilityTensor,
+                                          Rpp32f *saltProbabilityTensor,
+                                          Rpp32f *saltValueTensor,
+                                          Rpp32f *pepperValueTensor,
+                                          Rpp32u seed,
+                                          RpptROIPtr roiTensorPtrSrc,
+                                          RpptRoiType roiType,
+                                          rppHandle_t rppHandle)
+{
+    for(int i = 0; i < srcDescPtr->n; i++)
+        if (!RPPINRANGE(noiseProbabilityTensor[i], 0, 1) || !RPPINRANGE(saltProbabilityTensor[i], 0, 1) || !RPPINRANGE(saltValueTensor[i], 0, 1) || !RPPINRANGE(pepperValueTensor[i], 0, 1))
+            return RPP_ERROR_INVALID_ARGUMENTS;
+
+    RppLayoutParams layoutParams = get_layout_params(srcDescPtr->layout, srcDescPtr->c);
+    RpptXorwowState xorwowInitialState;
+    xorwowInitialState.x[0] = 123456789U + seed;
+    xorwowInitialState.x[1] = 362436069U + seed;
+    xorwowInitialState.x[2] = 521288629U + seed;
+    xorwowInitialState.x[3] = 88675123U + seed;
+    xorwowInitialState.x[4] = 5783321U + seed;
+    xorwowInitialState.counter = 6615241U + seed;
+
+    if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
+    {
+        salt_and_pepper_noise_u8_u8_host_tensor(static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                                srcDescPtr,
+                                                static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                                dstDescPtr,
+                                                noiseProbabilityTensor,
+                                                saltProbabilityTensor,
+                                                saltValueTensor,
+                                                pepperValueTensor,
+                                                &xorwowInitialState,
+                                                roiTensorPtrSrc,
+                                                roiType,
+                                                layoutParams);
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
+    {
+        salt_and_pepper_noise_f16_f16_host_tensor((Rpp16f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                                  srcDescPtr,
+                                                  (Rpp16f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                                  dstDescPtr,
+                                                  noiseProbabilityTensor,
+                                                  saltProbabilityTensor,
+                                                  saltValueTensor,
+                                                  pepperValueTensor,
+                                                  &xorwowInitialState,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  layoutParams);
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
+    {
+        salt_and_pepper_noise_f32_f32_host_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + srcDescPtr->offsetInBytes),
+                                                  srcDescPtr,
+                                                  (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                                  dstDescPtr,
+                                                  noiseProbabilityTensor,
+                                                  saltProbabilityTensor,
+                                                  saltValueTensor,
+                                                  pepperValueTensor,
+                                                  &xorwowInitialState,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  layoutParams);
+    }
+    else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
+    {
+        salt_and_pepper_noise_i8_i8_host_tensor(static_cast<Rpp8s*>(srcPtr) + srcDescPtr->offsetInBytes,
+                                                srcDescPtr,
+                                                static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                                dstDescPtr,
+                                                noiseProbabilityTensor,
+                                                saltProbabilityTensor,
+                                                saltValueTensor,
+                                                pepperValueTensor,
+                                                &xorwowInitialState,
+                                                roiTensorPtrSrc,
+                                                roiType,
+                                                layoutParams);
+    }
+
+    return RPP_SUCCESS;
+}

--- a/src/modules/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/rppt_tensor_effects_augmentations.cpp
@@ -458,13 +458,8 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
             return RPP_ERROR_INVALID_ARGUMENTS;
 
     RppLayoutParams layoutParams = get_layout_params(srcDescPtr->layout, srcDescPtr->c);
-#if __AVX2__
-    RpptXorwowState xorwowInitialState[8];
-    rpp_host_rng_xorwow_f32_initialize_8seed_stream(xorwowInitialState, seed);
-#else
-    RpptXorwowState xorwowInitialState[4];
-    rpp_host_rng_xorwow_f32_initialize_4seed_stream(xorwowInitialState, seed);
-#endif
+    RpptXorwowState xorwowInitialState[SIMD_FLOAT_VECTOR_LENGTH];
+    rpp_host_rng_xorwow_f32_initialize_multiseed_stream<SIMD_FLOAT_VECTOR_LENGTH>(xorwowInitialState, seed);
 
     if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
     {

--- a/src/modules/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/rppt_tensor_effects_augmentations.cpp
@@ -378,12 +378,12 @@ RppStatus rppt_salt_and_pepper_noise_gpu(RppPtr_t srcPtr,
     copy_param_float(pepperValueTensor, rpp::deref(rppHandle), paramIndex++);
 
     RpptXorwowState xorwowInitialState;
-    xorwowInitialState.x[0] = 123456789U + seed;
-    xorwowInitialState.x[1] = 362436069U + seed;
-    xorwowInitialState.x[2] = 521288629U + seed;
-    xorwowInitialState.x[3] = 88675123U + seed;
-    xorwowInitialState.x[4] = 5783321U + seed;
-    xorwowInitialState.counter = 6615241U + seed;
+    xorwowInitialState.x[0] = 0x75BCD15 + seed;
+    xorwowInitialState.x[1] = 0x159A55E5 + seed;
+    xorwowInitialState.x[2] = 0x1F123BB5 + seed;
+    xorwowInitialState.x[3] = 0x5491333 + seed;
+    xorwowInitialState.x[4] = 0x583F19 + seed;
+    xorwowInitialState.counter = 0x64F0C9 + seed;
 
     RpptXorwowState *d_xorwowInitialStatePtr;
     d_xorwowInitialStatePtr = (RpptXorwowState *) rpp::deref(rppHandle).GetInitHandle()->mem.mgpu.maskArr.floatmem;

--- a/src/modules/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/rppt_tensor_effects_augmentations.cpp
@@ -458,8 +458,13 @@ RppStatus rppt_salt_and_pepper_noise_host(RppPtr_t srcPtr,
             return RPP_ERROR_INVALID_ARGUMENTS;
 
     RppLayoutParams layoutParams = get_layout_params(srcDescPtr->layout, srcDescPtr->c);
+#if __AVX2__
+    RpptXorwowState xorwowInitialState[8];
+    rpp_host_rng_xorwow_f32_initialize_8seed_stream(xorwowInitialState, seed);
+#else
     RpptXorwowState xorwowInitialState[4];
-    rpp_host_rng_xorwow_f32_initialize(xorwowInitialState, seed);
+    rpp_host_rng_xorwow_f32_initialize_4seed_stream(xorwowInitialState, seed);
+#endif
 
     if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
     {

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -58,6 +58,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -77,9 +88,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -111,6 +123,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -256,6 +271,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -756,6 +778,88 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.05f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 1.0f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                    start = clock();
+
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -59,6 +59,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -83,9 +94,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -119,6 +131,10 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        outputFormatToggle = 0;
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         outputFormatToggle = 0;
         break;
     case 13:
@@ -266,6 +282,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -768,6 +791,88 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.05f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 1.0f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                    start = clock();
+
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -58,6 +58,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -77,9 +88,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -111,6 +123,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -256,6 +271,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -832,6 +854,88 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.05f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 1.0f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                    start = clock();
+
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HIP_NEW/generatePerformanceLogs.py
+++ b/utilities/rpp-performancetests/HIP_NEW/generatePerformanceLogs.py
@@ -238,6 +238,30 @@ elif profilingOption == "YES":
                             except IOError:
                                 print("Unable to open case results")
                                 continue
+                    elif (CASE_NUM == 8) and TYPE.startswith("Tensor"):
+                        NOISETYPE_LIST = [0, 1, 2]
+                        # Loop through extra param noiseType
+                        for NOISETYPE in NOISETYPE_LIST:
+                            # Write into csv file
+                            CASE_FILE_PATH = CASE_RESULTS_DIR + "/output_case" + str(CASE_NUM) + "_bitDepth" + str(BIT_DEPTH) + "_oft" + str(OFT) + "_noiseType" + str(NOISETYPE) + ".stats.csv"
+                            print("CASE_FILE_PATH = " + CASE_FILE_PATH)
+                            try:
+                                case_file = open(CASE_FILE_PATH,'r')
+                                for line in case_file:
+                                    print(line)
+                                    if not(line.startswith('"Name"')):
+                                        if TYPE in TENSOR_TYPE_LIST:
+                                            new_file.write(line)
+                                            d_counter[TYPE] = d_counter[TYPE] + 1
+                                        elif TYPE in BATCHPD_TYPE_LIST:
+                                            if prev != line.split(",")[0]:
+                                                new_file.write(line)
+                                                prev = line.split(",")[0]
+                                                d_counter[TYPE] = d_counter[TYPE] + 1
+                                case_file.close()
+                            except IOError:
+                                print("Unable to open case results")
+                                continue
                     else:
                         # Write into csv file
                         CASE_FILE_PATH = CASE_RESULTS_DIR + "/output_case" + str(CASE_NUM) + "_bitDepth" + str(BIT_DEPTH) + "_oft" + str(OFT) + ".stats.csv"

--- a/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
+++ b/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
@@ -221,6 +221,13 @@ do
                         printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
@@ -242,6 +249,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
@@ -311,6 +326,13 @@ do
                         printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
@@ -332,6 +354,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
@@ -401,6 +431,13 @@ do
                         printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
                     done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                    done
                 else
                     printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
                     ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
@@ -422,6 +459,14 @@ do
                         mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                         rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                    done
+                elif [[ "$case" -eq 8 ]]
+                then
+                    for ((noiseType=0;noiseType<3;noiseType++))
+                    do
+                        mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                        printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                        rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
                     done
                 else
                     mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -61,6 +61,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -80,9 +91,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -114,6 +126,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -253,6 +268,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -674,6 +696,86 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.1f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 0.6f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    start_omp = omp_get_wtime();
+                    start = clock();
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
@@ -62,6 +62,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -86,9 +97,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -120,6 +132,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -249,6 +264,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -672,6 +694,86 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.1f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 0.6f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    start_omp = omp_get_wtime();
+                    start = clock();
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
@@ -61,6 +61,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -80,9 +91,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[4]);
     int test_case = atoi(argv[5]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[7]) : atoi(argv[6]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[6]) : 1;
@@ -114,6 +126,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -253,6 +268,13 @@ int main(int argc, char **argv)
         interpolationTypeName = get_interpolation_type(additionalParam, interpolationType);
         strcat(func, "_interpolationType");
         strcat(func, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
     }
 
     // Get number of images
@@ -750,6 +772,86 @@ int main(int argc, char **argv)
                 missingFuncFlag = 1;
             else
                 missingFuncFlag = 1;
+
+            break;
+        }
+        case 8:
+        {
+            test_case_name = "noise";
+
+            switch(additionalParam)
+            {
+                case 0:
+                {
+                    Rpp32f noiseProbabilityTensor[images];
+                    Rpp32f saltProbabilityTensor[images];
+                    Rpp32f saltValueTensor[images];
+                    Rpp32f pepperValueTensor[images];
+                    Rpp32u seed = 1255459;
+                    for (i = 0; i < images; i++)
+                    {
+                        noiseProbabilityTensor[i] = 0.1f;
+                        saltProbabilityTensor[i] = 0.5f;
+                        saltValueTensor[i] = 0.6f;
+                        pepperValueTensor[i] = 0.0f;
+                    }
+
+                    // Uncomment to run test case with an xywhROI override
+                    /*for (i = 0; i < images; i++)
+                    {
+                        roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                        roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                        roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                        roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                    }*/
+
+                    // Uncomment to run test case with an ltrbROI override
+                    /*for (i = 0; i < images; i++)
+                        roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                        roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                        roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                        roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                    }
+                    roiTypeSrc = RpptRoiType::LTRB;
+                    roiTypeDst = RpptRoiType::LTRB;*/
+
+                    start_omp = omp_get_wtime();
+                    start = clock();
+                    if (ip_bitDepth == 0)
+                        rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 1)
+                        rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 2)
+                        rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 3)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 4)
+                        missingFuncFlag = 1;
+                    else if (ip_bitDepth == 5)
+                        rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                    else if (ip_bitDepth == 6)
+                        missingFuncFlag = 1;
+                    else
+                        missingFuncFlag = 1;
+
+                    break;
+                }
+                case 1:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                case 2:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+                default:
+                {
+                    missingFuncFlag = 1;
+                    break;
+                }
+            }
 
             break;
         }

--- a/utilities/rpp-performancetests/HOST_NEW/rawLogsGenScript.sh
+++ b/utilities/rpp-performancetests/HOST_NEW/rawLogsGenScript.sh
@@ -156,7 +156,14 @@ do
             printf "\n./BatchPD_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/BatchPD_host_pkd3_host_raw_performance_log.txt"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_host_pkd3_host_raw_performance_log.txt"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do
@@ -205,7 +212,14 @@ do
             printf "\n./BatchPD_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/BatchPD_host_pln1_host_raw_performance_log.txt"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_host_pln1_host_raw_performance_log.txt"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do
@@ -254,7 +268,14 @@ do
             printf "\n./BatchPD_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" | tee -a "$DST_FOLDER/BatchPD_host_pln3_host_raw_performance_log.txt"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<6;noiseType++))
+                do
+                    printf "\n./Tensor_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0" | tee -a "$DST_FOLDER/Tensor_host_pln3_host_raw_performance_log.txt"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -58,6 +58,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -78,9 +89,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -113,6 +125,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -265,6 +280,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -764,6 +788,88 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.05f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                start = clock();
+
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pkd3.cpp
@@ -806,7 +806,7 @@ int main(int argc, char **argv)
                 Rpp32u seed = 1255459;
                 for (i = 0; i < images; i++)
                 {
-                    noiseProbabilityTensor[i] = 0.05f;
+                    noiseProbabilityTensor[i] = 0.1f;
                     saltProbabilityTensor[i] = 0.5f;
                     saltValueTensor[i] = 1.0f;
                     pepperValueTensor[i] = 0.0f;

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
                 Rpp32u seed = 1255459;
                 for (i = 0; i < images; i++)
                 {
-                    noiseProbabilityTensor[i] = 0.05f;
+                    noiseProbabilityTensor[i] = 0.1f;
                     saltProbabilityTensor[i] = 0.5f;
                     saltValueTensor[i] = 1.0f;
                     pepperValueTensor[i] = 0.0f;

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln1.cpp
@@ -59,6 +59,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -84,9 +95,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -121,6 +133,10 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        outputFormatToggle = 0;
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         outputFormatToggle = 0;
         break;
     case 13:
@@ -275,6 +291,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -775,6 +800,88 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.05f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                start = clock();
+
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -58,6 +58,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -78,9 +89,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
+    bool additionalParamCase = (test_case == 8 || test_case == 24 || test_case == 40 || test_case == 41 || test_case == 49);
     bool kernelSizeCase = (test_case == 40 || test_case == 41 || test_case == 49);
     bool interpolationTypeCase = (test_case == 24);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -113,6 +125,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -265,6 +280,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -839,6 +863,88 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.05f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                hipMemcpy(d_roiTensorPtrSrc, roiTensorPtrSrc, images * sizeof(RpptROI), hipMemcpyHostToDevice);
+
+                start = clock();
+
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_gpu(d_input, srcDescPtr, d_output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf16, srcDescPtr, d_outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_gpu(d_inputf32, srcDescPtr, d_outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_gpu(d_inputi8, srcDescPtr, d_outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, d_roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Tensor_hip_pln3.cpp
@@ -881,7 +881,7 @@ int main(int argc, char **argv)
                 Rpp32u seed = 1255459;
                 for (i = 0; i < images; i++)
                 {
-                    noiseProbabilityTensor[i] = 0.05f;
+                    noiseProbabilityTensor[i] = 0.1f;
                     saltProbabilityTensor[i] = 0.5f;
                     saltValueTensor[i] = 1.0f;
                     pepperValueTensor[i] = 0.0f;

--- a/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
+++ b/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
@@ -219,6 +219,13 @@ do
                     printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                     ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
                 done
+            elif [[ "$case" -eq 8 ]]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
+                done
             else
                 printf "\n./Tensor_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
                 ./Tensor_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
@@ -295,6 +302,13 @@ do
                     printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                     ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
                 done
+            elif [[ "$case" -eq 8 ]]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
+                done
             else
                 printf "\n./Tensor_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
                 ./Tensor_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
@@ -370,6 +384,13 @@ do
                 do
                     printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
                     ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "0"
+                done
+            elif [[ "$case" -eq 8 ]]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
                 done
             else
                 printf "\n./Tensor_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -61,6 +61,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -81,9 +92,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -116,6 +128,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -262,6 +277,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -685,6 +709,86 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.1f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                start_omp = omp_get_wtime();
+                start = clock();
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
@@ -62,6 +62,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -87,9 +98,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -122,6 +134,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -258,6 +273,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -683,6 +707,86 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.1f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                start_omp = omp_get_wtime();
+                start = clock();
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
@@ -61,6 +61,17 @@ std::string get_interpolation_type(unsigned int val, RpptInterpolationType &inte
     }
 }
 
+std::string get_noise_type(unsigned int val)
+{
+    switch(val)
+    {
+        case 0: return "SaltAndPepper";
+        case 1: return "Gaussian";
+        case 2: return "Shot";
+        default:return "SaltAndPepper";
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Handle inputs
@@ -81,9 +92,10 @@ int main(int argc, char **argv)
     unsigned int outputFormatToggle = atoi(argv[5]);
     int test_case = atoi(argv[6]);
 
-    bool additionalParamCase = (test_case == 21);
+    bool additionalParamCase = (test_case == 8 || test_case == 21);
     bool kernelSizeCase = false;
     bool interpolationTypeCase = (test_case == 21);
+    bool noiseTypeCase = (test_case == 8);
 
     unsigned int verbosity = additionalParamCase ? atoi(argv[8]) : atoi(argv[7]);
     unsigned int additionalParam = additionalParamCase ? atoi(argv[7]) : 1;
@@ -116,6 +128,9 @@ int main(int argc, char **argv)
         break;
     case 2:
         strcpy(funcName, "blend");
+        break;
+    case 8:
+        strcpy(funcName, "noise");
         break;
     case 13:
         strcpy(funcName, "exposure");
@@ -262,6 +277,15 @@ int main(int argc, char **argv)
         strcat(func, interpolationTypeName.c_str());
         strcat(dst, "_interpolationType");
         strcat(dst, interpolationTypeName.c_str());
+    }
+    else if (noiseTypeCase)
+    {
+        std::string noiseTypeName;
+        noiseTypeName = get_noise_type(additionalParam);
+        strcat(func, "_noiseType");
+        strcat(func, noiseTypeName.c_str());
+        strcat(dst, "_noiseType");
+        strcat(dst, noiseTypeName.c_str());
     }
 
     printf("\nRunning %s...", func);
@@ -761,6 +785,86 @@ int main(int argc, char **argv)
             missingFuncFlag = 1;
         else
             missingFuncFlag = 1;
+
+        break;
+    }
+    case 8:
+    {
+        test_case_name = "noise";
+
+        switch(additionalParam)
+        {
+            case 0:
+            {
+                Rpp32f noiseProbabilityTensor[images];
+                Rpp32f saltProbabilityTensor[images];
+                Rpp32f saltValueTensor[images];
+                Rpp32f pepperValueTensor[images];
+                Rpp32u seed = 1255459;
+                for (i = 0; i < images; i++)
+                {
+                    noiseProbabilityTensor[i] = 0.1f;
+                    saltProbabilityTensor[i] = 0.5f;
+                    saltValueTensor[i] = 1.0f;
+                    pepperValueTensor[i] = 0.0f;
+                }
+
+                // Uncomment to run test case with an xywhROI override
+                /*for (i = 0; i < images; i++)
+                {
+                    roiTensorPtrSrc[i].xywhROI.xy.x = 0;
+                    roiTensorPtrSrc[i].xywhROI.xy.y = 0;
+                    roiTensorPtrSrc[i].xywhROI.roiWidth = 100;
+                    roiTensorPtrSrc[i].xywhROI.roiHeight = 180;
+                }*/
+
+                // Uncomment to run test case with an ltrbROI override
+                /*for (i = 0; i < images; i++)
+                    roiTensorPtrSrc[i].ltrbROI.lt.x = 50;
+                    roiTensorPtrSrc[i].ltrbROI.lt.y = 30;
+                    roiTensorPtrSrc[i].ltrbROI.rb.x = 210;
+                    roiTensorPtrSrc[i].ltrbROI.rb.y = 210;
+                }
+                roiTypeSrc = RpptRoiType::LTRB;
+                roiTypeDst = RpptRoiType::LTRB;*/
+
+                start_omp = omp_get_wtime();
+                start = clock();
+                if (ip_bitDepth == 0)
+                    rppt_salt_and_pepper_noise_host(input, srcDescPtr, output, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 1)
+                    rppt_salt_and_pepper_noise_host(inputf16, srcDescPtr, outputf16, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 2)
+                    rppt_salt_and_pepper_noise_host(inputf32, srcDescPtr, outputf32, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 3)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 4)
+                    missingFuncFlag = 1;
+                else if (ip_bitDepth == 5)
+                    rppt_salt_and_pepper_noise_host(inputi8, srcDescPtr, outputi8, dstDescPtr, noiseProbabilityTensor, saltProbabilityTensor, saltValueTensor, pepperValueTensor, seed, roiTensorPtrSrc, roiTypeSrc, handle);
+                else if (ip_bitDepth == 6)
+                    missingFuncFlag = 1;
+                else
+                    missingFuncFlag = 1;
+
+                break;
+            }
+            case 1:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            case 2:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+            default:
+            {
+                missingFuncFlag = 1;
+                break;
+            }
+        }
 
         break;
     }

--- a/utilities/rpp-unittests/HOST_NEW/testAllScript.sh
+++ b/utilities/rpp-unittests/HOST_NEW/testAllScript.sh
@@ -200,7 +200,14 @@ do
             printf "\n./BatchPD_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do
@@ -269,7 +276,14 @@ do
             printf "\n./BatchPD_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do
@@ -338,7 +352,14 @@ do
             printf "\n./BatchPD_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case 0"
             ./BatchPD_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0"
 
-            if [ "$case" -eq 21 ]
+            if [ "$case" -eq 8 ]
+            then
+                for ((noiseType=0;noiseType<3;noiseType++))
+                do
+                    printf "\n./Tensor_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                    ./Tensor_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "0"
+                done
+            elif [ "$case" -eq 21 ]
             then
                 for ((interpolationType=0;interpolationType<6;interpolationType++))
                 do


### PR DESCRIPTION
- Adds rpp support for salt and pepper noise tensor on hip and host.
- Introduces generic 4 and 8 element seed-streams and support to running xorwow on SSE and AVX2 generating a vector of 8 random float numbers in parallel per CPU thread.
- Support for U8/F32/F16/I8, NCHW/NHWC/toggle is added.
- Adds corresponding unit tests and performance tests.