### PR TITLE
ReadMe mods - OpenCV 3.x or 4.x to match MIVisionX compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ RPP is developed for **Linux** operating system.
         unzip 4.5.5.zip
         cd opencv-4.5.5/
 
--  OpenCV 3.4.0 or OpenCV 4.5.5 installation
+-   OpenCV 3.4.0 or OpenCV 4.5.5 installation
 
         mkdir build
         cd build

--- a/Readme.md
+++ b/Readme.md
@@ -50,16 +50,32 @@ RPP is developed for **Linux** operating system.
         sudo cp half-files/include/half.hpp /usr/local/include/
 
 ## Prerequisites for Test Suite
--   OpenCV 3.4.0
+-   OpenCV 3.4.0 or OpenCV 4.5.5 pre-requisites
+
+        sudo apt-get update
+        sudo -S apt-get -y --allow-unauthenticated install build-essential libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy
+        sudo -S apt-get -y --allow-unauthenticated install libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev unzip wget
+
+-   OpenCV 3.4.0 or OpenCV 4.5.5 download
 
         wget https://github.com/opencv/opencv/archive/3.4.0.zip
         unzip 3.4.0.zip
         cd opencv-3.4.0/
+
+    OR
+
+        wget https://github.com/opencv/opencv/archive/4.5.5.zip
+        unzip 4.5.5.zip
+        cd opencv-4.5.5/
+
+-  OpenCV 3.4.0 or OpenCV 4.5.5 installation
+
         mkdir build
         cd build
-        cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local ..
-        make -j<number of threads>
-        sudo make install
+        cmake -D WITH_OPENCL=OFF -D WITH_OPENCLAMDFFT=OFF -D WITH_OPENCLAMDBLAS=OFF -D WITH_VA_INTEL=OFF -D WITH_OPENCL_SVM=OFF -D CMAKE_INSTALL_PREFIX=/usr/local ..
+        sudo -S make -j128 <Or other number of threads to use>
+        sudo -S make install
+        sudo -S ldconfig
 
 ## Supported Functionalities and Variants
 


### PR DESCRIPTION
- RPP uses OpenCV just for unit-testing purposes.
- The PR adds ReadMe mods to mention use of either OpenCV 3.x or 4.x to match the MIVisionX compatibility and gives the same install instructions from MIVisionX-setup.py
- Tested with installation of OpenCV 3.4.0 (no-change) or OpenCV 4.5.5 on rocm 5.1.1 docker from rocm DockerHub.