### PR TITLE
MacOS failure - Define MacOS Function

### DIFF
--- a/src/modules/rppt_tensor_geometric_augmentations.cpp
+++ b/src/modules/rppt_tensor_geometric_augmentations.cpp
@@ -30,6 +30,10 @@ THE SOFTWARE.
 #include "hip/hip_tensor_geometric_augmentations.hpp"
 #endif // HIP_COMPILE
 
+#if __APPLE__
+#define sincosf __sincosf
+#endif
+
 /******************** crop ********************/
 
 RppStatus rppt_crop_host(RppPtr_t srcPtr,


### PR DESCRIPTION
Build on **MacOS**

```
cmake ../rpp 
-- Apple macOS Detected -- GPU Support turned OFF
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- AMD Radeon Performance Primitives (RPP) Version -- 0.99
-- AMD RPP install path set to -- /usr/local
-- AMD RPP Backend set to -- CPU
-- AMD RPP Build Type -- Release
-- Found Boost: /usr/local/lib/cmake/Boost-1.81.0/BoostConfig.cmake (found version "1.81.0") found components: filesystem system 
-- Found OpenMP_CXX: -Xclang -fopenmp (found version "5.0") 
-- Found OpenMP: TRUE (found version "5.0")  
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- The C compiler identification is AppleClang 14.0.0.14000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- modules -- Adding custom commands to rpp_kernels
-- AMD RPP modules -- Include Directories:/Users/kiritigowda/work/rpp-kiriti/rpp/src/include/common/
-- amd_rpp set to build with ENABLE_SIMD_INTRINSICS
-- amd_rpp -- Using Compiler - Path:/usr/bin/clang++	Version:14.0.0.14000029	Compiler:AppleClang
-- amd_rpp -- CMAKE_CXX_FLAGS: -O3 -Ofast -DNDEBUG -fPIC -mavx2 -mf16c -mfma -std=gnu++14
-- amd_rpp -- Link Libraries: Boost::filesystem;Boost::system;OpenMP::OpenMP_CXX;Threads::Threads;stdc++
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/kiritigowda/work/rpp-kiriti/build
kiritigowda@Kiritis-MacBook-Pro build % make
[  3%] Building CXX object addkernels/CMakeFiles/addkernels.dir/include_inliner.cpp.o
[  6%] Building CXX object addkernels/CMakeFiles/addkernels.dir/addkernels.cpp.o
[ 10%] Linking CXX executable ../bin/addkernels
[ 10%] Built target addkernels
[ 13%] Inlining RPP kernels
[ 16%] Building CXX object src/modules/CMakeFiles/modules.dir/binary_cache.cpp.o
[ 20%] Building CXX object src/modules/CMakeFiles/modules.dir/handle_api.cpp.o
[ 23%] Building CXX object src/modules/CMakeFiles/modules.dir/handlehost.cpp.o
[ 26%] Building CXX object src/modules/CMakeFiles/modules.dir/kernel_cache.cpp.o
[ 30%] Building CXX object src/modules/CMakeFiles/modules.dir/logger.cpp.o
[ 33%] Building CXX object src/modules/CMakeFiles/modules.dir/md5.cpp.o
[ 36%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_advanced_augmentations.cpp.o
[ 40%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_arithmetic_operations.cpp.o
[ 43%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_color_model_conversions.cpp.o
[ 46%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_computer_vision.cpp.o
[ 50%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_filter_operations.cpp.o
[ 53%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_fused_functions.cpp.o
[ 56%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_geometry_transforms.cpp.o
[ 60%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_image_augmentations.cpp.o
[ 63%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_logical_operations.cpp.o
[ 66%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_morphological_operations.cpp.o
[ 70%] Building CXX object src/modules/CMakeFiles/modules.dir/rppi_statistical_operations.cpp.o
[ 73%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_color_augmentations.cpp.o
[ 76%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_data_exchange_operations.cpp.o
[ 80%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_effects_augmentations.cpp.o
[ 83%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_filter_augmentations.cpp.o
[ 86%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_geometric_augmentations.cpp.o
[ 90%] Building CXX object src/modules/CMakeFiles/modules.dir/rppt_tensor_morphological_operations.cpp.o
[ 93%] Building CXX object src/modules/CMakeFiles/modules.dir/kernel.cpp.o
[ 96%] Building CXX object src/modules/CMakeFiles/modules.dir/kernel_includes.cpp.o
[ 96%] Built target modules
[100%] Linking CXX shared library lib/libamd_rpp.dylib
[100%] Built target amd_rpp

```