### PR TITLE
possible fix for cmake link bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,10 @@ else()
 endif()
 
 # Set Default Compiler for OCL/CPU
-if(NOT "${BACKEND}" STREQUAL "HIP")
+#if(NOT "${BACKEND}" STREQUAL "HIP")
     set(CMAKE_C_COMPILER clang)
     set(CMAKE_CXX_COMPILER clang++)
-endif()
+#endif()
 set(CMAKE_CXX_STANDARD 14)
 
 project(amd_rpp CXX)

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -90,7 +90,8 @@ if( "${BACKEND}" STREQUAL "HIP")
     message("-- ${Green}HIP kernels added${ColourReset}")
 
     # Set HIP compiler and flags
-    set(CMAKE_CXX_COMPILER ${COMPILER_FOR_HIP})
+    #set(CMAKE_CXX_COMPILER ${COMPILER_FOR_HIP})
+    set(CMAKE_CXX_COMPILER ${ROCM_PATH}/bin/hipcc)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${HIP_HIPCC_FLAGS}")
 
     # Add HIP specific preprocessor flags


### PR DESCRIPTION
@kiritigowda : can you try this and see if it fixes the CMake issue. I have switched to hipcc and removed the clang commented code for HIP backend