### PR TITLE
RPP test_suite/HIP build fix

### DIFF
--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -35,7 +35,6 @@ THE SOFTWARE.
 #include <omp.h>
 #include <fstream>
 #include <turbojpeg.h>
-#include <experimental/filesystem>
 
 using namespace cv;
 using namespace std;


### PR DESCRIPTION
Fixes HOST passing / HIP failing issue in rpp test_suite. The issue was replicable on MI100 ubuntu 22.04 + rocm-5.6.0-11969 at compute-artifactory.amd.com:5000/rocm-plus-docker/compute-rocm-dkms-no-npi-hipclang:11969-ubuntu-22.04-stg2

![HIP build fail](https://user-images.githubusercontent.com/52214183/234426460-95b6022f-e655-44dc-9dad-4d1e28ae2c4e.png)


HIP test passing:
![HIP passing](https://user-images.githubusercontent.com/52214183/234426915-e33285b4-5a7f-4216-929a-daafc6961c7f.png)

@paveltc @LakshmiKumar23 @kiritigowda 