### PR TITLE
Update dependabot configuration and documentation dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "noCI"
+    reviewers:
+      - "samjwu"

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,2 +1,1 @@
-rocm-docs-core==0.18.2
-
+rocm-docs-core==0.18.4

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -46,6 +46,10 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==6.7.0
+    # via sphinx
+importlib-resources==5.12.0
+    # via rocm-docs-core
 jinja2==3.1.2
     # via
     #   myst-parser
@@ -85,6 +89,8 @@ pyjwt[crypto]==2.6.0
     # via pygithub
 pynacl==1.5.0
     # via pygithub
+pytz==2023.3
+    # via babel
 pyyaml==6.0
     # via
     #   myst-parser
@@ -94,7 +100,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.18.2
+rocm-docs-core==0.18.4
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb
@@ -143,3 +149,7 @@ urllib3==1.26.15
     # via requests
 wrapt==1.15.0
     # via deprecated
+zipp==3.15.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,9 @@
 
 from rocm_docs import ROCmDocs
 
+
+external_projects_current_project = "rpp"
+
 docs_core = ROCmDocs("RPP Documentation")
 docs_core.setup()
 


### PR DESCRIPTION
resolves: dependabot configuration and documentation dependencies

Summary of proposed changes:
-  Adds noCI labels for dependabot PRs because Read the Docs CI is separate from Jenkins/Math CI
-  Update rocm-docs-core to version 0.18.4