### PR TITLE
Replace all _lds occurrences to _smem

### DIFF
--- a/src/include/hip/rpp_hip_common.hpp
+++ b/src/include/hip/rpp_hip_common.hpp
@@ -121,6 +121,9 @@ struct RPPTensorFunctionMetaData
 #define RPP_2POW32_INV_DIV_2            1.164153218e-10f    // RPP_2POW32_INV / 2
 #define RPP_2POW32_INV_MUL_2PI          1.46291812e-09f     // (1 / 2^32) * 2PI
 #define RPP_2POW32_INV_MUL_2PI_DIV_2    7.3145906e-10f      // RPP_2POW32_INV_MUL_2PI / 2
+#define SMEM_LENGTH_X                   128                 // Shared memory length of 128 cols to efficiently utilize all 16 LOCAL_THREADS_X as 16 * 8-byte vectorized global read/writes per thread = 128 bytes, fitting in 32 banks 4 byte wide
+#define SMEM_LENGTH_Y_1C                16                  // Shared memory length of 16 rows to efficiently utilize all 16 LOCAL_THREADS_Y as 1 128-byte-long row per thread (single channel greyscale)
+#define SMEM_LENGTH_Y_3C                48                  // Shared memory length of 48 rows to efficiently utilize all 16 LOCAL_THREADS_Y as 3 128-byte-long rows per thread (three channel rgb)
 
 #define BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define BYTE_TO_BINARY(byte)  \

--- a/src/modules/hip/kernel/box_filter.hpp
+++ b/src/modules/hip/kernel/box_filter.hpp
@@ -293,7 +293,7 @@ __global__ void box_filter_3x3_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -309,21 +309,21 @@ __global__ void box_filter_3x3_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -331,15 +331,15 @@ __global__ void box_filter_3x3_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -363,7 +363,7 @@ __global__ void box_filter_5x5_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -379,21 +379,21 @@ __global__ void box_filter_5x5_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -401,21 +401,21 @@ __global__ void box_filter_5x5_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -439,7 +439,7 @@ __global__ void box_filter_7x7_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -455,21 +455,21 @@ __global__ void box_filter_7x7_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -477,27 +477,27 @@ __global__ void box_filter_7x7_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -521,7 +521,7 @@ __global__ void box_filter_9x9_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -537,21 +537,21 @@ __global__ void box_filter_9x9_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -559,33 +559,33 @@ __global__ void box_filter_9x9_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -612,7 +612,7 @@ __global__ void box_filter_3x3_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -620,18 +620,18 @@ __global__ void box_filter_3x3_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -645,18 +645,18 @@ __global__ void box_filter_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -668,18 +668,18 @@ __global__ void box_filter_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -705,7 +705,7 @@ __global__ void box_filter_5x5_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -713,20 +713,20 @@ __global__ void box_filter_5x5_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -740,20 +740,20 @@ __global__ void box_filter_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -765,20 +765,20 @@ __global__ void box_filter_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -804,7 +804,7 @@ __global__ void box_filter_7x7_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -812,22 +812,22 @@ __global__ void box_filter_7x7_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -841,22 +841,22 @@ __global__ void box_filter_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -868,22 +868,22 @@ __global__ void box_filter_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -909,7 +909,7 @@ __global__ void box_filter_9x9_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -917,24 +917,24 @@ __global__ void box_filter_9x9_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -948,24 +948,24 @@ __global__ void box_filter_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -977,24 +977,24 @@ __global__ void box_filter_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1021,7 +1021,7 @@ __global__ void box_filter_3x3_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1037,21 +1037,21 @@ __global__ void box_filter_3x3_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1059,15 +1059,15 @@ __global__ void box_filter_3x3_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1091,7 +1091,7 @@ __global__ void box_filter_5x5_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1107,21 +1107,21 @@ __global__ void box_filter_5x5_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1129,21 +1129,21 @@ __global__ void box_filter_5x5_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1167,7 +1167,7 @@ __global__ void box_filter_7x7_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1183,21 +1183,21 @@ __global__ void box_filter_7x7_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1205,27 +1205,27 @@ __global__ void box_filter_7x7_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1249,7 +1249,7 @@ __global__ void box_filter_9x9_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1265,21 +1265,21 @@ __global__ void box_filter_9x9_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1287,33 +1287,33 @@ __global__ void box_filter_9x9_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1339,7 +1339,7 @@ __global__ void box_filter_3x3_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1361,15 +1361,15 @@ __global__ void box_filter_3x3_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1377,15 +1377,15 @@ __global__ void box_filter_3x3_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1409,7 +1409,7 @@ __global__ void box_filter_5x5_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1431,15 +1431,15 @@ __global__ void box_filter_5x5_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1447,21 +1447,21 @@ __global__ void box_filter_5x5_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1485,7 +1485,7 @@ __global__ void box_filter_7x7_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1507,15 +1507,15 @@ __global__ void box_filter_7x7_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1523,27 +1523,27 @@ __global__ void box_filter_7x7_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1567,7 +1567,7 @@ __global__ void box_filter_9x9_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1589,15 +1589,15 @@ __global__ void box_filter_9x9_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1605,33 +1605,33 @@ __global__ void box_filter_9x9_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        box_filter_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        box_filter_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }

--- a/src/modules/hip/kernel/dilate.hpp
+++ b/src/modules/hip/kernel/dilate.hpp
@@ -293,7 +293,7 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -309,21 +309,21 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -331,15 +331,15 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -363,7 +363,7 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -379,21 +379,21 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -401,21 +401,21 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -439,7 +439,7 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -455,21 +455,21 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -477,27 +477,27 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -521,7 +521,7 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -537,21 +537,21 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -559,33 +559,33 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -612,7 +612,7 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -620,18 +620,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -645,18 +645,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -668,18 +668,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -705,7 +705,7 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -713,20 +713,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -740,20 +740,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -765,20 +765,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -804,7 +804,7 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -812,22 +812,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -841,22 +841,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -868,22 +868,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -909,7 +909,7 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -917,24 +917,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -948,24 +948,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -977,24 +977,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1021,7 +1021,7 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1037,21 +1037,21 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1059,15 +1059,15 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1091,7 +1091,7 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1107,21 +1107,21 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1129,21 +1129,21 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1167,7 +1167,7 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1183,21 +1183,21 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1205,27 +1205,27 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1249,7 +1249,7 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1265,21 +1265,21 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
-        *(uint2 *)src_lds_channel[0] = (uint2)0;
-        *(uint2 *)src_lds_channel[1] = (uint2)0;
-        *(uint2 *)src_lds_channel[2] = (uint2)0;
+        *(uint2 *)srcShared_channel[0] = (uint2)0;
+        *(uint2 *)srcShared_channel[1] = (uint2)0;
+        *(uint2 *)srcShared_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1287,33 +1287,33 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1339,7 +1339,7 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1361,15 +1361,15 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1377,15 +1377,15 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1409,7 +1409,7 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1431,15 +1431,15 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1447,21 +1447,21 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1485,7 +1485,7 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1507,15 +1507,15 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1523,27 +1523,27 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1567,7 +1567,7 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1589,15 +1589,15 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1605,33 +1605,33 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }

--- a/src/modules/hip/kernel/dilate.hpp
+++ b/src/modules/hip/kernel/dilate.hpp
@@ -293,7 +293,7 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -309,21 +309,21 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -331,15 +331,15 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -363,7 +363,7 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -379,21 +379,21 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -401,21 +401,21 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -439,7 +439,7 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -455,21 +455,21 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -477,27 +477,27 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -521,7 +521,7 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -537,21 +537,21 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -559,33 +559,33 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -612,7 +612,7 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -620,18 +620,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -645,18 +645,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -668,18 +668,18 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -705,7 +705,7 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -713,20 +713,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -740,20 +740,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -765,20 +765,20 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -804,7 +804,7 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -812,22 +812,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -841,22 +841,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -868,22 +868,22 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -909,7 +909,7 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -917,24 +917,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
     sum_f8.f4[1] = (float4) 0;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -948,24 +948,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -977,24 +977,24 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 0;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = (uint2)0;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1021,7 +1021,7 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1037,21 +1037,21 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1059,15 +1059,15 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1091,7 +1091,7 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1107,21 +1107,21 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1129,21 +1129,21 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1167,7 +1167,7 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1183,21 +1183,21 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1205,27 +1205,27 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1249,7 +1249,7 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1265,21 +1265,21 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
-        *(uint2 *)srcShared_channel[0] = (uint2)0;
-        *(uint2 *)srcShared_channel[1] = (uint2)0;
-        *(uint2 *)srcShared_channel[2] = (uint2)0;
+        *(uint2 *)src_smem_channel[0] = (uint2)0;
+        *(uint2 *)src_smem_channel[1] = (uint2)0;
+        *(uint2 *)src_smem_channel[2] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1287,33 +1287,33 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1339,7 +1339,7 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1361,15 +1361,15 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1377,15 +1377,15 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1409,7 +1409,7 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1431,15 +1431,15 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1447,21 +1447,21 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1485,7 +1485,7 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1507,15 +1507,15 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1523,27 +1523,27 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1567,7 +1567,7 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1589,15 +1589,15 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = (uint2)0;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = (uint2)0;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1605,33 +1605,33 @@ __global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        dilate_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        dilate_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }

--- a/src/modules/hip/kernel/erode.hpp
+++ b/src/modules/hip/kernel/erode.hpp
@@ -293,7 +293,7 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -309,24 +309,24 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -334,15 +334,15 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -366,7 +366,7 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -382,24 +382,24 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -407,21 +407,21 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -445,7 +445,7 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -461,24 +461,24 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -486,27 +486,27 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -530,7 +530,7 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -546,24 +546,24 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -571,33 +571,33 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -624,7 +624,7 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -635,18 +635,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -660,18 +660,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -683,18 +683,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -720,7 +720,7 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -731,20 +731,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -758,20 +758,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -783,20 +783,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -822,7 +822,7 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -833,22 +833,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -862,22 +862,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -889,22 +889,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -930,7 +930,7 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar src_lds[16][128];
+    __shared__ uchar srcShared[16][128];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -941,24 +941,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -972,24 +972,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1001,24 +1001,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_lds[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&src_lds[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1045,7 +1045,7 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1061,24 +1061,24 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1086,15 +1086,15 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1118,7 +1118,7 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1134,24 +1134,24 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1159,21 +1159,21 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1197,7 +1197,7 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1213,24 +1213,24 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1238,27 +1238,27 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1282,7 +1282,7 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1298,24 +1298,24 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *src_lds_channel[3];
-    src_lds_channel[0] = &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    src_lds_channel[1] = &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    src_lds_channel[2] = &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *srcShared_channel[3];
+    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_lds_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)src_lds_channel[0] = borderVal;
-        *(uint2 *)src_lds_channel[1] = borderVal;
-        *(uint2 *)src_lds_channel[2] = borderVal;
+        *(uint2 *)srcShared_channel[0] = borderVal;
+        *(uint2 *)srcShared_channel[1] = borderVal;
+        *(uint2 *)srcShared_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1323,33 +1323,33 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1375,7 +1375,7 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1397,18 +1397,18 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1416,15 +1416,15 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1448,7 +1448,7 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1470,18 +1470,18 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1489,21 +1489,21 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1527,7 +1527,7 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1549,18 +1549,18 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1568,27 +1568,27 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1612,7 +1612,7 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar src_lds[48][128];
+    __shared__ uchar srcShared[48][128];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1634,18 +1634,18 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&src_lds[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1653,33 +1653,33 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&src_lds[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }

--- a/src/modules/hip/kernel/erode.hpp
+++ b/src/modules/hip/kernel/erode.hpp
@@ -293,7 +293,7 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -309,24 +309,24 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -334,15 +334,15 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -366,7 +366,7 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -382,24 +382,24 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -407,21 +407,21 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -445,7 +445,7 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -461,24 +461,24 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -486,27 +486,27 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -530,7 +530,7 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNH.x) + (id_y_o * dstStridesNH.y) + id_x_o * 3;
@@ -546,24 +546,24 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -571,33 +571,33 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -624,7 +624,7 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -635,18 +635,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -660,18 +660,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -683,18 +683,18 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -720,7 +720,7 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -731,20 +731,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -758,20 +758,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -783,20 +783,20 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -822,7 +822,7 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -833,22 +833,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -862,22 +862,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -889,22 +889,22 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -930,7 +930,7 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float8 sum_f8;
-    __shared__ uchar srcShared[16][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_1C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -941,24 +941,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
     borderVal.y = 0xFFFFFFFF;
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
     else
-        *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
         rpp_hip_adjust_range(dstPtr, &sum_f8);
         rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
     }
@@ -972,24 +972,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1001,24 +1001,24 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
         sum_f8.f4[1] = (float4) 255;
         if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
-            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &srcShared[hipThreadIdx_y][hipThreadIdx_x8]);
+            rpp_hip_load8_to_uchar8(srcPtr + srcIdx, &src_smem[hipThreadIdx_y][hipThreadIdx_x8]);
         else
-            *(uint2 *)&srcShared[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
+            *(uint2 *)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = borderVal;
         __syncthreads();
         if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
             (id_y_o < roiTensorPtrSrc[id_z].xywhROI.roiHeight) &&
             (hipThreadIdx_x < tileSize.x) &&
             (hipThreadIdx_y < tileSize.y))
         {
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
-            erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y    ][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 1][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 2][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 3][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 4][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 5][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 6][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 7][hipThreadIdx_x8], &sum_f8);
+            erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y + 8][hipThreadIdx_x8], &sum_f8);
             rpp_hip_adjust_range(dstPtr, &sum_f8);
             rpp_hip_pack_float8_and_store8(dstPtr + dstIdx, &sum_f8);
         }
@@ -1045,7 +1045,7 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1061,24 +1061,24 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1086,15 +1086,15 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1118,7 +1118,7 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1134,24 +1134,24 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1159,21 +1159,21 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1197,7 +1197,7 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1213,24 +1213,24 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1238,27 +1238,27 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1282,7 +1282,7 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int srcIdx = (id_z * srcStridesNH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNH.y) + ((id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x) * 3);
     int dstIdx = (id_z * dstStridesNCH.x) + (id_y_o * dstStridesNCH.z) + id_x_o;
@@ -1298,24 +1298,24 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
     hipThreadIdx_y_channel.y = hipThreadIdx_y + 16;
     hipThreadIdx_y_channel.z = hipThreadIdx_y + 32;
 
-    uchar *srcShared_channel[3];
-    srcShared_channel[0] = &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
-    srcShared_channel[1] = &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
-    srcShared_channel[2] = &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
+    uchar *src_smem_channel[3];
+    src_smem_channel[0] = &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8];
+    src_smem_channel[1] = &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8];
+    src_smem_channel[2] = &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8];
 
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, srcShared_channel);
+        rpp_hip_load24_pkd3_to_uchar8_pln3(srcPtr + srcIdx, src_smem_channel);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)srcShared_channel[0] = borderVal;
-        *(uint2 *)srcShared_channel[1] = borderVal;
-        *(uint2 *)srcShared_channel[2] = borderVal;
+        *(uint2 *)src_smem_channel[0] = borderVal;
+        *(uint2 *)src_smem_channel[1] = borderVal;
+        *(uint2 *)src_smem_channel[2] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1323,33 +1323,33 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pln3(dstPtr + dstIdx, dstStridesNCH.y, &sum_f24);
     }
@@ -1375,7 +1375,7 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1397,18 +1397,18 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1416,15 +1416,15 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_3x3_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_3x3_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1448,7 +1448,7 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1470,18 +1470,18 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1489,21 +1489,21 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_5x5_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_5x5_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1527,7 +1527,7 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1549,18 +1549,18 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1568,27 +1568,27 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_7x7_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_7x7_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }
@@ -1612,7 +1612,7 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
     int id_x_i = id_x_o - padLength;
     int id_y_i = id_y_o - padLength;
     d_float24 sum_f24;
-    __shared__ uchar srcShared[48][128];
+    __shared__ uchar src_smem[SMEM_LENGTH_Y_3C][SMEM_LENGTH_X];
 
     int3 srcIdx;
     srcIdx.x = (id_z * srcStridesNCH.x) + ((id_y_i + roiTensorPtrSrc[id_z].xywhROI.xy.y) * srcStridesNCH.z) + (id_x_i + roiTensorPtrSrc[id_z].xywhROI.xy.x);
@@ -1634,18 +1634,18 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
     if ((id_x_i >= -(int)padLength) && (id_x_i < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
         (id_y_i >= 0) && (id_y_i < roiTensorPtrSrc[id_z].xywhROI.roiHeight))
     {
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
-        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.x, &src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.y, &src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
+        rpp_hip_load8_to_uchar8(srcPtr + srcIdx.z, &src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8]);
     }
     else
     {
         uint2 borderVal;
         borderVal.x = 0xFFFFFFFF;
         borderVal.y = 0xFFFFFFFF;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
-        *(uint2 *)&srcShared[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.x][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8] = borderVal;
+        *(uint2 *)&src_smem[hipThreadIdx_y_channel.z][hipThreadIdx_x8] = borderVal;
     }
     __syncthreads();
     if ((id_x_o < roiTensorPtrSrc[id_z].xywhROI.roiWidth) &&
@@ -1653,33 +1653,33 @@ __global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
         (hipThreadIdx_x < tileSize.x) &&
         (hipThreadIdx_y < tileSize.y))
     {
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
-        erode_9x9_row_hip_compute(&srcShared[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x    ][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y    ][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z    ][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 1][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 1][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 1][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 2][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 2][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 2][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 3][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 3][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 3][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 4][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 4][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 4][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 5][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 5][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 5][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 6][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 6][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 6][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 7][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 7][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 7][hipThreadIdx_x8], &sum_f24.f8[2]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.x + 8][hipThreadIdx_x8], &sum_f24.f8[0]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.y + 8][hipThreadIdx_x8], &sum_f24.f8[1]);
+        erode_9x9_row_hip_compute(&src_smem[hipThreadIdx_y_channel.z + 8][hipThreadIdx_x8], &sum_f24.f8[2]);
         rpp_hip_adjust_range(dstPtr, &sum_f24);
         rpp_hip_pack_float24_pln3_and_store24_pkd3(dstPtr + dstIdx, &sum_f24);
     }


### PR DESCRIPTION
@rrawther @asalmanp This PR just replaces all _lds occurrences to Shared in RPP tensor functions.
Once the Gaussian Filter PR is merged, all Shared mem sizes will be changed to the preprocessor define for better readability.