### PR TITLE
RPP Tensor HIP kernels rename - "_tensor" to "_hip_tensor"

### DIFF
--- a/src/modules/hip/kernel/blend.hpp
+++ b/src/modules/hip/kernel/blend.hpp
@@ -8,7 +8,7 @@ __device__ void blend_hip_compute(d_float8 *src1_f8, d_float8 *src2_f8, d_float8
 }
 
 template <typename T>
-__global__ void blend_pkd_tensor(T *srcPtr1,
+__global__ void blend_pkd_hip_tensor(T *srcPtr1,
                                  T *srcPtr2,
                                  uint2 srcStridesNH,
                                  T *dstPtr,
@@ -39,7 +39,7 @@ __global__ void blend_pkd_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void blend_pln_tensor(T *srcPtr1,
+__global__ void blend_pln_hip_tensor(T *srcPtr1,
                                  T *srcPtr2,
                                  uint3 srcStridesNCH,
                                  T *dstPtr,
@@ -90,7 +90,7 @@ __global__ void blend_pln_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void blend_pkd3_pln3_tensor(T *srcPtr1,
+__global__ void blend_pkd3_pln3_hip_tensor(T *srcPtr1,
                                        T *srcPtr2,
                                        uint2 srcStridesNH,
                                        T *dstPtr,
@@ -123,7 +123,7 @@ __global__ void blend_pkd3_pln3_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void blend_pln3_pkd3_tensor(T *srcPtr1,
+__global__ void blend_pln3_pkd3_hip_tensor(T *srcPtr1,
                                        T *srcPtr2,
                                        uint3 srcStridesNCH,
                                        T *dstPtr,
@@ -177,7 +177,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(blend_pkd_tensor,
+        hipLaunchKernelGGL(blend_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -192,7 +192,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(blend_pln_tensor,
+        hipLaunchKernelGGL(blend_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -210,7 +210,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(blend_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(blend_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -226,7 +226,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(blend_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(blend_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/box_filter.hpp
+++ b/src/modules/hip/kernel/box_filter.hpp
@@ -277,7 +277,7 @@ __device__ void box_filter_9x9_row_hip_compute(uchar *srcPtr, d_float8 *dst_f8)
 
 // kernelSize = 3
 template <typename T>
-__global__ void box_filter_3x3_pkd_tensor(T *srcPtr,
+__global__ void box_filter_3x3_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -347,7 +347,7 @@ __global__ void box_filter_3x3_pkd_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void box_filter_5x5_pkd_tensor(T *srcPtr,
+__global__ void box_filter_5x5_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -423,7 +423,7 @@ __global__ void box_filter_5x5_pkd_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void box_filter_7x7_pkd_tensor(T *srcPtr,
+__global__ void box_filter_7x7_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -505,7 +505,7 @@ __global__ void box_filter_7x7_pkd_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void box_filter_9x9_pkd_tensor(T *srcPtr,
+__global__ void box_filter_9x9_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -595,7 +595,7 @@ __global__ void box_filter_9x9_pkd_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void box_filter_3x3_pln_tensor(T *srcPtr,
+__global__ void box_filter_3x3_pln_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -688,7 +688,7 @@ __global__ void box_filter_3x3_pln_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void box_filter_5x5_pln_tensor(T *srcPtr,
+__global__ void box_filter_5x5_pln_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -787,7 +787,7 @@ __global__ void box_filter_5x5_pln_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void box_filter_7x7_pln_tensor(T *srcPtr,
+__global__ void box_filter_7x7_pln_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -892,7 +892,7 @@ __global__ void box_filter_7x7_pln_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void box_filter_9x9_pln_tensor(T *srcPtr,
+__global__ void box_filter_9x9_pln_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -1005,7 +1005,7 @@ __global__ void box_filter_9x9_pln_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void box_filter_3x3_pkd3_pln3_tensor(T *srcPtr,
+__global__ void box_filter_3x3_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -1075,7 +1075,7 @@ __global__ void box_filter_3x3_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void box_filter_5x5_pkd3_pln3_tensor(T *srcPtr,
+__global__ void box_filter_5x5_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -1151,7 +1151,7 @@ __global__ void box_filter_5x5_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void box_filter_7x7_pkd3_pln3_tensor(T *srcPtr,
+__global__ void box_filter_7x7_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -1233,7 +1233,7 @@ __global__ void box_filter_7x7_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void box_filter_9x9_pkd3_pln3_tensor(T *srcPtr,
+__global__ void box_filter_9x9_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -1323,7 +1323,7 @@ __global__ void box_filter_9x9_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void box_filter_3x3_pln3_pkd3_tensor(T *srcPtr,
+__global__ void box_filter_3x3_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -1393,7 +1393,7 @@ __global__ void box_filter_3x3_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void box_filter_5x5_pln3_pkd3_tensor(T *srcPtr,
+__global__ void box_filter_5x5_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -1469,7 +1469,7 @@ __global__ void box_filter_5x5_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void box_filter_7x7_pln3_pkd3_tensor(T *srcPtr,
+__global__ void box_filter_7x7_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -1551,7 +1551,7 @@ __global__ void box_filter_7x7_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void box_filter_9x9_pln3_pkd3_tensor(T *srcPtr,
+__global__ void box_filter_9x9_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -1671,7 +1671,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
 
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(box_filter_3x3_pkd_tensor,
+            hipLaunchKernelGGL(box_filter_3x3_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1686,7 +1686,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(box_filter_5x5_pkd_tensor,
+            hipLaunchKernelGGL(box_filter_5x5_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1701,7 +1701,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(box_filter_7x7_pkd_tensor,
+            hipLaunchKernelGGL(box_filter_7x7_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1716,7 +1716,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(box_filter_9x9_pkd_tensor,
+            hipLaunchKernelGGL(box_filter_9x9_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1734,7 +1734,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
     {
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(box_filter_3x3_pln_tensor,
+            hipLaunchKernelGGL(box_filter_3x3_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1750,7 +1750,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(box_filter_5x5_pln_tensor,
+            hipLaunchKernelGGL(box_filter_5x5_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1766,7 +1766,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(box_filter_7x7_pln_tensor,
+            hipLaunchKernelGGL(box_filter_7x7_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1782,7 +1782,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(box_filter_9x9_pln_tensor,
+            hipLaunchKernelGGL(box_filter_9x9_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1803,7 +1803,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         {
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(box_filter_3x3_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(box_filter_3x3_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1818,7 +1818,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(box_filter_5x5_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(box_filter_5x5_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1833,7 +1833,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(box_filter_7x7_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(box_filter_7x7_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1848,7 +1848,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(box_filter_9x9_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(box_filter_9x9_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1868,7 +1868,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
 
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(box_filter_3x3_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(box_filter_3x3_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1883,7 +1883,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(box_filter_5x5_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(box_filter_5x5_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1898,7 +1898,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(box_filter_7x7_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(box_filter_7x7_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1913,7 +1913,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(box_filter_9x9_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(box_filter_9x9_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,

--- a/src/modules/hip/kernel/brightness.hpp
+++ b/src/modules/hip/kernel/brightness.hpp
@@ -26,7 +26,7 @@ __device__ void brightness_hip_compute(half *srcPtr, d_float8 *src_f8, d_float8 
 }
 
 template <typename T>
-__global__ void brightness_pkd_tensor(T *srcPtr,
+__global__ void brightness_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -57,7 +57,7 @@ __global__ void brightness_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void brightness_pln_tensor(T *srcPtr,
+__global__ void brightness_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -106,7 +106,7 @@ __global__ void brightness_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void brightness_pkd3_pln3_tensor(T *srcPtr,
+__global__ void brightness_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -139,7 +139,7 @@ __global__ void brightness_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void brightness_pln3_pkd3_tensor(T *srcPtr,
+__global__ void brightness_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -192,7 +192,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(brightness_pkd_tensor,
+        hipLaunchKernelGGL(brightness_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -207,7 +207,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(brightness_pln_tensor,
+        hipLaunchKernelGGL(brightness_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -225,7 +225,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(brightness_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(brightness_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -241,7 +241,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(brightness_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(brightness_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/color_cast.hpp
+++ b/src/modules/hip/kernel/color_cast.hpp
@@ -28,7 +28,7 @@ __device__ void color_cast_hip_compute(half *srcPtr, d_float8 *src_f8, d_float8 
 }
 
 template <typename T>
-__global__ void color_cast_pkd_tensor(T *srcPtr,
+__global__ void color_cast_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -63,7 +63,7 @@ __global__ void color_cast_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_cast_pln_tensor(T *srcPtr,
+__global__ void color_cast_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -98,7 +98,7 @@ __global__ void color_cast_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_cast_pkd3_pln3_tensor(T *srcPtr,
+__global__ void color_cast_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -133,7 +133,7 @@ __global__ void color_cast_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_cast_pln3_pkd3_tensor(T *srcPtr,
+__global__ void color_cast_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -191,7 +191,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-            hipLaunchKernelGGL(color_cast_pkd_tensor,
+            hipLaunchKernelGGL(color_cast_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -206,7 +206,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(color_cast_pln_tensor,
+            hipLaunchKernelGGL(color_cast_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -221,7 +221,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(color_cast_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(color_cast_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -237,7 +237,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(color_cast_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(color_cast_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/color_to_greyscale.hpp
+++ b/src/modules/hip/kernel/color_to_greyscale.hpp
@@ -26,7 +26,7 @@ __device__ void color_to_greyscale_hip_compute(half *srcPtr, d_float24 *src_f24,
 }
 
 template <typename T>
-__global__ void color_to_greyscale_pkd3_pln1_tensor(T *srcPtr,
+__global__ void color_to_greyscale_pkd3_pln1_hip_tensor(T *srcPtr,
                                                     uint2 srcStridesNH,
                                                     T *dstPtr,
                                                     uint2 dstStridesNH,
@@ -59,7 +59,7 @@ __global__ void color_to_greyscale_pkd3_pln1_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_to_greyscale_pln3_pln1_tensor(T *srcPtr,
+__global__ void color_to_greyscale_pln3_pln1_hip_tensor(T *srcPtr,
                                                     uint3 srcStridesNCH,
                                                     T *dstPtr,
                                                     uint2 dstStridesNH,
@@ -109,7 +109,7 @@ RppStatus hip_exec_color_to_greyscale_tensor(T *srcPtr,
     if (srcDescPtr->layout == RpptLayout::NHWC)
     {
         globalThreads_x = (srcDescPtr->strides.hStride / 3 + 7) >> 3;
-        hipLaunchKernelGGL(color_to_greyscale_pkd3_pln1_tensor,
+        hipLaunchKernelGGL(color_to_greyscale_pkd3_pln1_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -123,7 +123,7 @@ RppStatus hip_exec_color_to_greyscale_tensor(T *srcPtr,
     }
     else if (srcDescPtr->layout == RpptLayout::NCHW)
     {
-        hipLaunchKernelGGL(color_to_greyscale_pln3_pln1_tensor,
+        hipLaunchKernelGGL(color_to_greyscale_pln3_pln1_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,

--- a/src/modules/hip/kernel/color_twist.hpp
+++ b/src/modules/hip/kernel/color_twist.hpp
@@ -119,7 +119,7 @@ __device__ void color_twist_hip_compute(schar *srcPtr, d_float24 *pix_f24, float
 }
 
 template <typename T>
-__global__ void color_twist_pkd_tensor(T *srcPtr,
+__global__ void color_twist_pkd_hip_tensor(T *srcPtr,
                                        uint2 srcStridesNH,
                                        T *dstPtr,
                                        uint2 dstStridesNH,
@@ -151,7 +151,7 @@ __global__ void color_twist_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_twist_pln_tensor(T *srcPtr,
+__global__ void color_twist_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -183,7 +183,7 @@ __global__ void color_twist_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_twist_pkd3_pln3_tensor(T *srcPtr,
+__global__ void color_twist_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -215,7 +215,7 @@ __global__ void color_twist_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void color_twist_pln3_pkd3_tensor(T *srcPtr,
+__global__ void color_twist_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -270,7 +270,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-            hipLaunchKernelGGL(color_twist_pkd_tensor,
+            hipLaunchKernelGGL(color_twist_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -287,7 +287,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(color_twist_pln_tensor,
+            hipLaunchKernelGGL(color_twist_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -304,7 +304,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(color_twist_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(color_twist_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -322,7 +322,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(color_twist_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(color_twist_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/contrast.hpp
+++ b/src/modules/hip/kernel/contrast.hpp
@@ -29,7 +29,7 @@ __device__ void contrast_hip_compute(half *srcPtr, d_float8 *pix_f8, d_float8 *c
 }
 
 template <typename T>
-__global__ void contrast_pkd_tensor(T *srcPtr,
+__global__ void contrast_pkd_hip_tensor(T *srcPtr,
                                     uint2 srcStridesNH,
                                     T *dstPtr,
                                     uint2 dstStridesNH,
@@ -59,7 +59,7 @@ __global__ void contrast_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void contrast_pln_tensor(T *srcPtr,
+__global__ void contrast_pln_hip_tensor(T *srcPtr,
                                     uint3 srcStridesNCH,
                                     T *dstPtr,
                                     uint3 dstStridesNCH,
@@ -107,7 +107,7 @@ __global__ void contrast_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void contrast_pkd3_pln3_tensor(T *srcPtr,
+__global__ void contrast_pkd3_pln3_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -140,7 +140,7 @@ __global__ void contrast_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void contrast_pln3_pkd3_tensor(T *srcPtr,
+__global__ void contrast_pln3_pkd3_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -193,7 +193,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(contrast_pkd_tensor,
+        hipLaunchKernelGGL(contrast_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -208,7 +208,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(contrast_pln_tensor,
+        hipLaunchKernelGGL(contrast_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -226,7 +226,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(contrast_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(contrast_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -242,7 +242,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(contrast_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(contrast_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/copy.hpp
+++ b/src/modules/hip/kernel/copy.hpp
@@ -2,7 +2,7 @@
 #include "rpp_hip_common.hpp"
 
 template <typename T>
-__global__ void copy_pkd3_pln3_tensor(T *srcPtr,
+__global__ void copy_pkd3_pln3_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -26,7 +26,7 @@ __global__ void copy_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void copy_pln3_pkd3_tensor(T *srcPtr,
+__global__ void copy_pln3_pkd3_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -71,7 +71,7 @@ RppStatus hip_exec_copy_tensor(T *srcPtr,
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(copy_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(copy_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -85,7 +85,7 @@ RppStatus hip_exec_copy_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(copy_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(copy_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/crop.hpp
+++ b/src/modules/hip/kernel/crop.hpp
@@ -2,7 +2,7 @@
 #include "rpp_hip_common.hpp"
 
 template <typename T>
-__global__ void crop_pkd_tensor(T *srcPtr,
+__global__ void crop_pkd_hip_tensor(T *srcPtr,
                                 uint2 srcStridesNH,
                                 T *dstPtr,
                                 uint2 dstStridesNH,
@@ -26,7 +26,7 @@ __global__ void crop_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void crop_pln_tensor(T *srcPtr,
+__global__ void crop_pln_hip_tensor(T *srcPtr,
                                 uint3 srcStridesNCH,
                                 T *dstPtr,
                                 uint3 dstStridesNCH,
@@ -62,7 +62,7 @@ __global__ void crop_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void crop_pkd3_pln3_tensor(T *srcPtr,
+__global__ void crop_pkd3_pln3_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -86,7 +86,7 @@ __global__ void crop_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void crop_pln3_pkd3_tensor(T *srcPtr,
+__global__ void crop_pln3_pkd3_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -130,7 +130,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(crop_pkd_tensor,
+        hipLaunchKernelGGL(crop_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -143,7 +143,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(crop_pln_tensor,
+        hipLaunchKernelGGL(crop_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -159,7 +159,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(crop_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(crop_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -173,7 +173,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(crop_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(crop_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/crop_mirror_normalize.hpp
@@ -37,7 +37,7 @@ __device__ void cmn_hip_compute(half *srcPtr, half *dstPtr, d_float8 *pix_f8, d_
 }
 
 template <typename T, typename U>
-__global__ void crop_mirror_normalize_pkd_tensor(T *srcPtr,
+__global__ void crop_mirror_normalize_pkd_hip_tensor(T *srcPtr,
                                                  uint2 srcStridesNH,
                                                  U *dstPtr,
                                                  uint2 dstStridesNH,
@@ -96,7 +96,7 @@ __global__ void crop_mirror_normalize_pkd_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void crop_mirror_normalize_pln_tensor(T *srcPtr,
+__global__ void crop_mirror_normalize_pln_hip_tensor(T *srcPtr,
                                                  uint3 srcStridesNCH,
                                                  U *dstPtr,
                                                  uint3 dstStridesNCH,
@@ -197,7 +197,7 @@ __global__ void crop_mirror_normalize_pln_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void crop_mirror_normalize_pkd3_pln3_tensor(T *srcPtr,
+__global__ void crop_mirror_normalize_pkd3_pln3_hip_tensor(T *srcPtr,
                                                        uint2 srcStridesNH,
                                                        U *dstPtr,
                                                        uint3 dstStridesNCH,
@@ -256,7 +256,7 @@ __global__ void crop_mirror_normalize_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void crop_mirror_normalize_pln3_pkd3_tensor(T *srcPtr,
+__global__ void crop_mirror_normalize_pln3_pkd3_hip_tensor(T *srcPtr,
                                                        uint3 srcStridesNCH,
                                                        U *dstPtr,
                                                        uint2 dstStridesNH,
@@ -335,7 +335,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(crop_mirror_normalize_pkd_tensor,
+        hipLaunchKernelGGL(crop_mirror_normalize_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -353,7 +353,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
     {
         if(srcDescPtr->c == 1)
         {
-            hipLaunchKernelGGL(crop_mirror_normalize_pln_tensor,
+            hipLaunchKernelGGL(crop_mirror_normalize_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -370,7 +370,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
         }
         else if(srcDescPtr->c == 3)
         {
-            hipLaunchKernelGGL(crop_mirror_normalize_pln_tensor,
+            hipLaunchKernelGGL(crop_mirror_normalize_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -390,7 +390,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(crop_mirror_normalize_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(crop_mirror_normalize_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -407,7 +407,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(crop_mirror_normalize_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(crop_mirror_normalize_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/dilate.hpp
+++ b/src/modules/hip/kernel/dilate.hpp
@@ -277,7 +277,7 @@ __device__ void dilate_9x9_row_hip_compute(uchar *srcPtr, d_float8 *dst_f8)
 
 // kernelSize = 3
 template <typename T>
-__global__ void dilate_3x3_pkd_tensor(T *srcPtr,
+__global__ void dilate_3x3_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -347,7 +347,7 @@ __global__ void dilate_3x3_pkd_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void dilate_5x5_pkd_tensor(T *srcPtr,
+__global__ void dilate_5x5_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -423,7 +423,7 @@ __global__ void dilate_5x5_pkd_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void dilate_7x7_pkd_tensor(T *srcPtr,
+__global__ void dilate_7x7_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -505,7 +505,7 @@ __global__ void dilate_7x7_pkd_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void dilate_9x9_pkd_tensor(T *srcPtr,
+__global__ void dilate_9x9_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -595,7 +595,7 @@ __global__ void dilate_9x9_pkd_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void dilate_3x3_pln_tensor(T *srcPtr,
+__global__ void dilate_3x3_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -688,7 +688,7 @@ __global__ void dilate_3x3_pln_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void dilate_5x5_pln_tensor(T *srcPtr,
+__global__ void dilate_5x5_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -787,7 +787,7 @@ __global__ void dilate_5x5_pln_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void dilate_7x7_pln_tensor(T *srcPtr,
+__global__ void dilate_7x7_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -892,7 +892,7 @@ __global__ void dilate_7x7_pln_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void dilate_9x9_pln_tensor(T *srcPtr,
+__global__ void dilate_9x9_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -1005,7 +1005,7 @@ __global__ void dilate_9x9_pln_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
+__global__ void dilate_3x3_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -1075,7 +1075,7 @@ __global__ void dilate_3x3_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
+__global__ void dilate_5x5_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -1151,7 +1151,7 @@ __global__ void dilate_5x5_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
+__global__ void dilate_7x7_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -1233,7 +1233,7 @@ __global__ void dilate_7x7_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
+__global__ void dilate_9x9_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -1323,7 +1323,7 @@ __global__ void dilate_9x9_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
+__global__ void dilate_3x3_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -1393,7 +1393,7 @@ __global__ void dilate_3x3_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
+__global__ void dilate_5x5_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -1469,7 +1469,7 @@ __global__ void dilate_5x5_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
+__global__ void dilate_7x7_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -1551,7 +1551,7 @@ __global__ void dilate_7x7_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void dilate_9x9_pln3_pkd3_tensor(T *srcPtr,
+__global__ void dilate_9x9_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -1671,7 +1671,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
 
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(dilate_3x3_pkd_tensor,
+            hipLaunchKernelGGL(dilate_3x3_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1686,7 +1686,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(dilate_5x5_pkd_tensor,
+            hipLaunchKernelGGL(dilate_5x5_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1701,7 +1701,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(dilate_7x7_pkd_tensor,
+            hipLaunchKernelGGL(dilate_7x7_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1716,7 +1716,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(dilate_9x9_pkd_tensor,
+            hipLaunchKernelGGL(dilate_9x9_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1734,7 +1734,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
     {
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(dilate_3x3_pln_tensor,
+            hipLaunchKernelGGL(dilate_3x3_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1750,7 +1750,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(dilate_5x5_pln_tensor,
+            hipLaunchKernelGGL(dilate_5x5_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1766,7 +1766,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(dilate_7x7_pln_tensor,
+            hipLaunchKernelGGL(dilate_7x7_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1782,7 +1782,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(dilate_9x9_pln_tensor,
+            hipLaunchKernelGGL(dilate_9x9_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1803,7 +1803,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         {
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(dilate_3x3_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(dilate_3x3_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1818,7 +1818,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(dilate_5x5_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(dilate_5x5_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1833,7 +1833,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(dilate_7x7_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(dilate_7x7_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1848,7 +1848,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(dilate_9x9_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(dilate_9x9_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1868,7 +1868,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
 
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(dilate_3x3_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(dilate_3x3_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1883,7 +1883,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(dilate_5x5_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(dilate_5x5_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1898,7 +1898,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(dilate_7x7_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(dilate_7x7_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1913,7 +1913,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(dilate_9x9_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(dilate_9x9_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,

--- a/src/modules/hip/kernel/erode.hpp
+++ b/src/modules/hip/kernel/erode.hpp
@@ -277,7 +277,7 @@ __device__ void erode_9x9_row_hip_compute(uchar *srcPtr, d_float8 *dst_f8)
 
 // kernelSize = 3
 template <typename T>
-__global__ void erode_3x3_pkd_tensor(T *srcPtr,
+__global__ void erode_3x3_pkd_hip_tensor(T *srcPtr,
                                      uint2 srcStridesNH,
                                      T *dstPtr,
                                      uint2 dstStridesNH,
@@ -350,7 +350,7 @@ __global__ void erode_3x3_pkd_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void erode_5x5_pkd_tensor(T *srcPtr,
+__global__ void erode_5x5_pkd_hip_tensor(T *srcPtr,
                                      uint2 srcStridesNH,
                                      T *dstPtr,
                                      uint2 dstStridesNH,
@@ -429,7 +429,7 @@ __global__ void erode_5x5_pkd_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void erode_7x7_pkd_tensor(T *srcPtr,
+__global__ void erode_7x7_pkd_hip_tensor(T *srcPtr,
                                      uint2 srcStridesNH,
                                      T *dstPtr,
                                      uint2 dstStridesNH,
@@ -514,7 +514,7 @@ __global__ void erode_7x7_pkd_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void erode_9x9_pkd_tensor(T *srcPtr,
+__global__ void erode_9x9_pkd_hip_tensor(T *srcPtr,
                                      uint2 srcStridesNH,
                                      T *dstPtr,
                                      uint2 dstStridesNH,
@@ -607,7 +607,7 @@ __global__ void erode_9x9_pkd_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void erode_3x3_pln_tensor(T *srcPtr,
+__global__ void erode_3x3_pln_hip_tensor(T *srcPtr,
                                      uint3 srcStridesNCH,
                                      T *dstPtr,
                                      uint3 dstStridesNCH,
@@ -703,7 +703,7 @@ __global__ void erode_3x3_pln_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void erode_5x5_pln_tensor(T *srcPtr,
+__global__ void erode_5x5_pln_hip_tensor(T *srcPtr,
                                      uint3 srcStridesNCH,
                                      T *dstPtr,
                                      uint3 dstStridesNCH,
@@ -805,7 +805,7 @@ __global__ void erode_5x5_pln_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void erode_7x7_pln_tensor(T *srcPtr,
+__global__ void erode_7x7_pln_hip_tensor(T *srcPtr,
                                      uint3 srcStridesNCH,
                                      T *dstPtr,
                                      uint3 dstStridesNCH,
@@ -913,7 +913,7 @@ __global__ void erode_7x7_pln_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void erode_9x9_pln_tensor(T *srcPtr,
+__global__ void erode_9x9_pln_hip_tensor(T *srcPtr,
                                      uint3 srcStridesNCH,
                                      T *dstPtr,
                                      uint3 dstStridesNCH,
@@ -1029,7 +1029,7 @@ __global__ void erode_9x9_pln_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
+__global__ void erode_3x3_pkd3_pln3_hip_tensor(T *srcPtr,
                                            uint2 srcStridesNH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -1102,7 +1102,7 @@ __global__ void erode_3x3_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
+__global__ void erode_5x5_pkd3_pln3_hip_tensor(T *srcPtr,
                                            uint2 srcStridesNH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -1181,7 +1181,7 @@ __global__ void erode_5x5_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
+__global__ void erode_7x7_pkd3_pln3_hip_tensor(T *srcPtr,
                                            uint2 srcStridesNH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -1266,7 +1266,7 @@ __global__ void erode_7x7_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
+__global__ void erode_9x9_pkd3_pln3_hip_tensor(T *srcPtr,
                                            uint2 srcStridesNH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -1359,7 +1359,7 @@ __global__ void erode_9x9_pkd3_pln3_tensor(T *srcPtr,
 
 // kernelSize = 3
 template <typename T>
-__global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
+__global__ void erode_3x3_pln3_pkd3_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint2 dstStridesNH,
@@ -1432,7 +1432,7 @@ __global__ void erode_3x3_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 5
 template <typename T>
-__global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
+__global__ void erode_5x5_pln3_pkd3_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint2 dstStridesNH,
@@ -1511,7 +1511,7 @@ __global__ void erode_5x5_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 7
 template <typename T>
-__global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
+__global__ void erode_7x7_pln3_pkd3_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint2 dstStridesNH,
@@ -1596,7 +1596,7 @@ __global__ void erode_7x7_pln3_pkd3_tensor(T *srcPtr,
 
 // kernelSize = 9
 template <typename T>
-__global__ void erode_9x9_pln3_pkd3_tensor(T *srcPtr,
+__global__ void erode_9x9_pln3_pkd3_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint2 dstStridesNH,
@@ -1719,7 +1719,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
 
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(erode_3x3_pkd_tensor,
+            hipLaunchKernelGGL(erode_3x3_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1734,7 +1734,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(erode_5x5_pkd_tensor,
+            hipLaunchKernelGGL(erode_5x5_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1749,7 +1749,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(erode_7x7_pkd_tensor,
+            hipLaunchKernelGGL(erode_7x7_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1764,7 +1764,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(erode_9x9_pkd_tensor,
+            hipLaunchKernelGGL(erode_9x9_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1782,7 +1782,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
     {
         if (kernelSize == 3)
         {
-            hipLaunchKernelGGL(erode_3x3_pln_tensor,
+            hipLaunchKernelGGL(erode_3x3_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1798,7 +1798,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 5)
         {
-            hipLaunchKernelGGL(erode_5x5_pln_tensor,
+            hipLaunchKernelGGL(erode_5x5_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1814,7 +1814,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 7)
         {
-            hipLaunchKernelGGL(erode_7x7_pln_tensor,
+            hipLaunchKernelGGL(erode_7x7_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1830,7 +1830,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if (kernelSize == 9)
         {
-            hipLaunchKernelGGL(erode_9x9_pln_tensor,
+            hipLaunchKernelGGL(erode_9x9_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -1851,7 +1851,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         {
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(erode_3x3_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(erode_3x3_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1866,7 +1866,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(erode_5x5_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(erode_5x5_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1881,7 +1881,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(erode_7x7_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(erode_7x7_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1896,7 +1896,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(erode_9x9_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(erode_9x9_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1916,7 +1916,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
 
             if (kernelSize == 3)
             {
-                hipLaunchKernelGGL(erode_3x3_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(erode_3x3_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1931,7 +1931,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 5)
             {
-                hipLaunchKernelGGL(erode_5x5_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(erode_5x5_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1946,7 +1946,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 7)
             {
-                hipLaunchKernelGGL(erode_7x7_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(erode_7x7_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -1961,7 +1961,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
             }
             else if (kernelSize == 9)
             {
-                hipLaunchKernelGGL(erode_9x9_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(erode_9x9_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/tileSize.x), ceil((float)globalThreads_y/tileSize.y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,

--- a/src/modules/hip/kernel/exposure.hpp
+++ b/src/modules/hip/kernel/exposure.hpp
@@ -25,7 +25,7 @@ __device__ void exposure_hip_compute(half *srcPtr, d_float8 *pix_f8, float4 *exp
 }
 
 template <typename T>
-__global__ void exposure_pkd_tensor(T *srcPtr,
+__global__ void exposure_pkd_hip_tensor(T *srcPtr,
                                     uint2 srcStridesNH,
                                     T *dstPtr,
                                     uint2 dstStridesNH,
@@ -55,7 +55,7 @@ __global__ void exposure_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void exposure_pln_tensor(T *srcPtr,
+__global__ void exposure_pln_hip_tensor(T *srcPtr,
                                     uint3 srcStridesNCH,
                                     T *dstPtr,
                                     uint3 dstStridesNCH,
@@ -102,7 +102,7 @@ __global__ void exposure_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void exposure_pkd3_pln3_tensor(T *srcPtr,
+__global__ void exposure_pkd3_pln3_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -134,7 +134,7 @@ __global__ void exposure_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void exposure_pln3_pkd3_tensor(T *srcPtr,
+__global__ void exposure_pln3_pkd3_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -185,7 +185,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(exposure_pkd_tensor,
+        hipLaunchKernelGGL(exposure_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -199,7 +199,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(exposure_pln_tensor,
+        hipLaunchKernelGGL(exposure_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -216,7 +216,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(exposure_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(exposure_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -231,7 +231,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(exposure_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(exposure_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/flip.hpp
+++ b/src/modules/hip/kernel/flip.hpp
@@ -2,7 +2,7 @@
 #include "rpp_hip_common.hpp"
 
 template <typename T>
-__global__ void flip_pkd_tensor(T *srcPtr,
+__global__ void flip_pkd_hip_tensor(T *srcPtr,
                                 uint2 srcStridesNH,
                                 T *dstPtr,
                                 uint2 dstStridesNH,
@@ -51,7 +51,7 @@ __global__ void flip_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void flip_pln_tensor(T *srcPtr,
+__global__ void flip_pln_hip_tensor(T *srcPtr,
                                 uint3 srcStridesNCH,
                                 T *dstPtr,
                                 uint3 dstStridesNCH,
@@ -129,7 +129,7 @@ __global__ void flip_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void flip_pkd3_pln3_tensor(T *srcPtr,
+__global__ void flip_pkd3_pln3_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -178,7 +178,7 @@ __global__ void flip_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void flip_pln3_pkd3_tensor(T *srcPtr,
+__global__ void flip_pln3_pkd3_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -247,7 +247,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(flip_pkd_tensor,
+        hipLaunchKernelGGL(flip_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -263,7 +263,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(flip_pln_tensor,
+        hipLaunchKernelGGL(flip_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -282,7 +282,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(flip_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(flip_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -299,7 +299,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(flip_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(flip_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/gamma_correction.hpp
+++ b/src/modules/hip/kernel/gamma_correction.hpp
@@ -38,7 +38,7 @@ __device__ void gamma_correction_hip_compute(half *srcPtr, d_float8 *src_f8, d_f
 }
 
 template <typename T>
-__global__ void gamma_correction_pkd_tensor(T *srcPtr,
+__global__ void gamma_correction_pkd_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -66,7 +66,7 @@ __global__ void gamma_correction_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gamma_correction_pln_tensor(T *srcPtr,
+__global__ void gamma_correction_pln_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -112,7 +112,7 @@ __global__ void gamma_correction_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gamma_correction_pkd3_pln3_tensor(T *srcPtr,
+__global__ void gamma_correction_pkd3_pln3_hip_tensor(T *srcPtr,
                                                   uint2 srcStridesNH,
                                                   T *dstPtr,
                                                   uint3 dstStridesNCH,
@@ -142,7 +142,7 @@ __global__ void gamma_correction_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gamma_correction_pln3_pkd3_tensor(T *srcPtr,
+__global__ void gamma_correction_pln3_pkd3_hip_tensor(T *srcPtr,
                                                   uint3 srcStridesNCH,
                                                   T *dstPtr,
                                                   uint2 dstStridesNH,
@@ -250,7 +250,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(gamma_correction_pkd_tensor,
+        hipLaunchKernelGGL(gamma_correction_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -264,7 +264,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(gamma_correction_pln_tensor,
+        hipLaunchKernelGGL(gamma_correction_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -281,7 +281,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(gamma_correction_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(gamma_correction_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -296,7 +296,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(gamma_correction_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(gamma_correction_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/gridmask.hpp
+++ b/src/modules/hip/kernel/gridmask.hpp
@@ -351,7 +351,7 @@ __device__ void gridmask_result_pln3_pkd3_hip_compute(half *srcPtr, uint srcStri
 // Gridmask kernels
 
 template <typename T>
-__global__ void gridmask_pkd_tensor(T *srcPtr,
+__global__ void gridmask_pkd_hip_tensor(T *srcPtr,
                                     uint2 srcStridesNH,
                                     T *dstPtr,
                                     uint2 dstStridesNH,
@@ -381,7 +381,7 @@ __global__ void gridmask_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gridmask_pln_tensor(T *srcPtr,
+__global__ void gridmask_pln_hip_tensor(T *srcPtr,
                                     uint3 srcStridesNCH,
                                     T *dstPtr,
                                     uint3 dstStridesNCH,
@@ -416,7 +416,7 @@ __global__ void gridmask_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gridmask_pkd3_pln3_tensor(T *srcPtr,
+__global__ void gridmask_pkd3_pln3_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -446,7 +446,7 @@ __global__ void gridmask_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gridmask_pln3_pkd3_tensor(T *srcPtr,
+__global__ void gridmask_pln3_pkd3_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -504,7 +504,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(gridmask_pkd_tensor,
+        hipLaunchKernelGGL(gridmask_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -520,7 +520,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(gridmask_pln_tensor,
+        hipLaunchKernelGGL(gridmask_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -539,7 +539,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(gridmask_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(gridmask_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -555,7 +555,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(gridmask_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(gridmask_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/lut.hpp
+++ b/src/modules/hip/kernel/lut.hpp
@@ -35,7 +35,7 @@ __device__ void lut_hip_compute(signed char *srcPtr, d_float8 *src_f8, d_float8 
 }
 
 template <typename T1, typename T2>
-__global__ void lut_pkd_tensor(T1 *srcPtr,
+__global__ void lut_pkd_hip_tensor(T1 *srcPtr,
                                uint2 srcStridesNH,
                                T2 *dstPtr,
                                uint2 dstStridesNH,
@@ -62,7 +62,7 @@ __global__ void lut_pkd_tensor(T1 *srcPtr,
 }
 
 template <typename T1, typename T2>
-__global__ void lut_pln_tensor(T1 *srcPtr,
+__global__ void lut_pln_hip_tensor(T1 *srcPtr,
                                uint3 srcStridesNCH,
                                T2 *dstPtr,
                                uint3 dstStridesNCH,
@@ -107,7 +107,7 @@ __global__ void lut_pln_tensor(T1 *srcPtr,
 }
 
 template <typename T1, typename T2>
-__global__ void lut_pkd3_pln3_tensor(T1 *srcPtr,
+__global__ void lut_pkd3_pln3_hip_tensor(T1 *srcPtr,
                                      uint2 srcStridesNH,
                                      T2 *dstPtr,
                                      uint3 dstStridesNCH,
@@ -136,7 +136,7 @@ __global__ void lut_pkd3_pln3_tensor(T1 *srcPtr,
 }
 
 template <typename T1, typename T2>
-__global__ void lut_pln3_pkd3_tensor(T1 *srcPtr,
+__global__ void lut_pln3_pkd3_hip_tensor(T1 *srcPtr,
                                      uint3 srcStridesNCH,
                                      T2 *dstPtr,
                                      uint2 dstStridesNH,
@@ -186,7 +186,7 @@ RppStatus hip_exec_lut_tensor(T1 *srcPtr,
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
-        hipLaunchKernelGGL(lut_pkd_tensor,
+        hipLaunchKernelGGL(lut_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -200,7 +200,7 @@ RppStatus hip_exec_lut_tensor(T1 *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(lut_pln_tensor,
+        hipLaunchKernelGGL(lut_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -217,7 +217,7 @@ RppStatus hip_exec_lut_tensor(T1 *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(lut_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(lut_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -232,7 +232,7 @@ RppStatus hip_exec_lut_tensor(T1 *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(lut_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(lut_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/noise_gaussian.hpp
+++ b/src/modules/hip/kernel/noise_gaussian.hpp
@@ -51,7 +51,7 @@ __device__ void gaussian_noise_24_adjusted_output_hip_compute(schar *srcPtr, d_f
 __device__ void gaussian_noise_24_adjusted_output_hip_compute(half *srcPtr, d_float24 *pix_f24) { }
 
 template <typename T>
-__global__ void gaussian_noise_pkd_tensor(T *srcPtr,
+__global__ void gaussian_noise_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -96,7 +96,7 @@ __global__ void gaussian_noise_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gaussian_noise_pln_tensor(T *srcPtr,
+__global__ void gaussian_noise_pln_hip_tensor(T *srcPtr,
                                           uint3 srcStridesNCH,
                                           T *dstPtr,
                                           uint3 dstStridesNCH,
@@ -164,7 +164,7 @@ __global__ void gaussian_noise_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gaussian_noise_pkd3_pln3_tensor(T *srcPtr,
+__global__ void gaussian_noise_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -209,7 +209,7 @@ __global__ void gaussian_noise_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void gaussian_noise_pln3_pkd3_tensor(T *srcPtr,
+__global__ void gaussian_noise_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -280,7 +280,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-        hipLaunchKernelGGL(gaussian_noise_pkd_tensor,
+        hipLaunchKernelGGL(gaussian_noise_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -297,7 +297,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(gaussian_noise_pln_tensor,
+        hipLaunchKernelGGL(gaussian_noise_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -317,7 +317,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(gaussian_noise_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(gaussian_noise_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -335,7 +335,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(gaussian_noise_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(gaussian_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -44,7 +44,7 @@ __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(schar *srcPtr, 
 __device__ void salt_and_pepper_noise_adjusted_input_hip_compute(half *srcPtr, float *saltValue, float *pepperValue) {}
 
 template <typename T>
-__global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
+__global__ void salt_and_pepper_noise_pkd_hip_tensor(T *srcPtr,
                                                  uint2 srcStridesNH,
                                                  T *dstPtr,
                                                  uint2 dstStridesNH,
@@ -94,7 +94,7 @@ __global__ void salt_and_pepper_noise_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void salt_and_pepper_noise_pln_tensor(T *srcPtr,
+__global__ void salt_and_pepper_noise_pln_hip_tensor(T *srcPtr,
                                                  uint3 srcStridesNCH,
                                                  T *dstPtr,
                                                  uint3 dstStridesNCH,
@@ -161,7 +161,7 @@ __global__ void salt_and_pepper_noise_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
+__global__ void salt_and_pepper_noise_pkd3_pln3_hip_tensor(T *srcPtr,
                                                        uint2 srcStridesNH,
                                                        T *dstPtr,
                                                        uint3 dstStridesNCH,
@@ -211,7 +211,7 @@ __global__ void salt_and_pepper_noise_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void salt_and_pepper_noise_pln3_pkd3_tensor(T *srcPtr,
+__global__ void salt_and_pepper_noise_pln3_pkd3_hip_tensor(T *srcPtr,
                                                        uint3 srcStridesNCH,
                                                        T *dstPtr,
                                                        uint2 dstStridesNH,
@@ -287,7 +287,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-        hipLaunchKernelGGL(salt_and_pepper_noise_pkd_tensor,
+        hipLaunchKernelGGL(salt_and_pepper_noise_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -306,7 +306,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(salt_and_pepper_noise_pln_tensor,
+        hipLaunchKernelGGL(salt_and_pepper_noise_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -328,7 +328,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(salt_and_pepper_noise_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(salt_and_pepper_noise_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -348,7 +348,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(salt_and_pepper_noise_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(salt_and_pepper_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/noise_shot.hpp
+++ b/src/modules/hip/kernel/noise_shot.hpp
@@ -50,7 +50,7 @@ __device__ void shot_noise_24_adjusted_output_hip_compute(schar *srcPtr, d_float
 __device__ void shot_noise_24_adjusted_output_hip_compute(half *srcPtr, d_float24 *pix_f24) { rpp_hip_math_multiply24_const(pix_f24, pix_f24, (float4)ONE_OVER_255); }
 
 template <typename T>
-__global__ void shot_noise_pkd_tensor(T *srcPtr,
+__global__ void shot_noise_pkd_hip_tensor(T *srcPtr,
                                       uint2 srcStridesNH,
                                       T *dstPtr,
                                       uint2 dstStridesNH,
@@ -101,7 +101,7 @@ __global__ void shot_noise_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void shot_noise_pln_tensor(T *srcPtr,
+__global__ void shot_noise_pln_hip_tensor(T *srcPtr,
                                       uint3 srcStridesNCH,
                                       T *dstPtr,
                                       uint3 dstStridesNCH,
@@ -200,7 +200,7 @@ __global__ void shot_noise_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void shot_noise_pkd3_pln3_tensor(T *srcPtr,
+__global__ void shot_noise_pkd3_pln3_hip_tensor(T *srcPtr,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
                                             uint3 dstStridesNCH,
@@ -251,7 +251,7 @@ __global__ void shot_noise_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void shot_noise_pln3_pkd3_tensor(T *srcPtr,
+__global__ void shot_noise_pln3_pkd3_hip_tensor(T *srcPtr,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
                                             uint2 dstStridesNH,
@@ -328,7 +328,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-        hipLaunchKernelGGL(shot_noise_pkd_tensor,
+        hipLaunchKernelGGL(shot_noise_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -344,7 +344,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(shot_noise_pln_tensor,
+        hipLaunchKernelGGL(shot_noise_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -363,7 +363,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(shot_noise_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(shot_noise_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -380,7 +380,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(shot_noise_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(shot_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/non_linear_blend.hpp
+++ b/src/modules/hip/kernel/non_linear_blend.hpp
@@ -36,7 +36,7 @@ __device__ void non_linear_blend_24_hip_compute(d_float24 *src1_f24, d_float24 *
 }
 
 template <typename T>
-__global__ void non_linear_blend_pkd_tensor(T *srcPtr1,
+__global__ void non_linear_blend_pkd_hip_tensor(T *srcPtr1,
                                             T *srcPtr2,
                                             uint2 srcStridesNH,
                                             T *dstPtr,
@@ -71,7 +71,7 @@ __global__ void non_linear_blend_pkd_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void non_linear_blend_pln_tensor(T *srcPtr1,
+__global__ void non_linear_blend_pln_hip_tensor(T *srcPtr1,
                                             T *srcPtr2,
                                             uint3 srcStridesNCH,
                                             T *dstPtr,
@@ -125,7 +125,7 @@ __global__ void non_linear_blend_pln_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void non_linear_blend_pkd3_pln3_tensor(T *srcPtr1,
+__global__ void non_linear_blend_pkd3_pln3_hip_tensor(T *srcPtr1,
                                                   T *srcPtr2,
                                                   uint2 srcStridesNH,
                                                   T *dstPtr,
@@ -160,7 +160,7 @@ __global__ void non_linear_blend_pkd3_pln3_tensor(T *srcPtr1,
 }
 
 template <typename T>
-__global__ void non_linear_blend_pln3_pkd3_tensor(T *srcPtr1,
+__global__ void non_linear_blend_pln3_pkd3_hip_tensor(T *srcPtr1,
                                                   T *srcPtr2,
                                                   uint3 srcStridesNCH,
                                                   T *dstPtr,
@@ -218,7 +218,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
     {
         globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
 
-        hipLaunchKernelGGL(non_linear_blend_pkd_tensor,
+        hipLaunchKernelGGL(non_linear_blend_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -233,7 +233,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(non_linear_blend_pln_tensor,
+        hipLaunchKernelGGL(non_linear_blend_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -251,7 +251,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(non_linear_blend_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(non_linear_blend_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -267,7 +267,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(non_linear_blend_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(non_linear_blend_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/resize.hpp
+++ b/src/modules/hip/kernel/resize.hpp
@@ -35,7 +35,7 @@ __device__ void resize_roi_generic_srcloc_and_weight_hip_compute(int roiLoc, int
 // -------------------- Set 1 - Nearest Neighbor Interpolation --------------------
 
 template <typename T>
-__global__ void resize_nearest_neighbor_pkd_tensor(T *srcPtr,
+__global__ void resize_nearest_neighbor_pkd_hip_tensor(T *srcPtr,
                                                    uint2 srcStridesNH,
                                                    T *dstPtr,
                                                    uint2 dstStridesNH,
@@ -68,7 +68,7 @@ __global__ void resize_nearest_neighbor_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_nearest_neighbor_pln_tensor(T *srcPtr,
+__global__ void resize_nearest_neighbor_pln_hip_tensor(T *srcPtr,
                                                    uint3 srcStridesNCH,
                                                    T *dstPtr,
                                                    uint3 dstStridesNCH,
@@ -117,7 +117,7 @@ __global__ void resize_nearest_neighbor_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
+__global__ void resize_nearest_neighbor_pkd3_pln3_hip_tensor(T *srcPtr,
                                                          uint2 srcStridesNH,
                                                          T *dstPtr,
                                                          uint3 dstStridesNCH,
@@ -150,7 +150,7 @@ __global__ void resize_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
+__global__ void resize_nearest_neighbor_pln3_pkd3_hip_tensor(T *srcPtr,
                                                          uint3 srcStridesNCH,
                                                          T *dstPtr,
                                                          uint2 dstStridesNH,
@@ -185,7 +185,7 @@ __global__ void resize_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
 // -------------------- Set 2 - Bilinear Interpolation --------------------
 
 template <typename T>
-__global__ void resize_bilinear_pkd_tensor(T *srcPtr,
+__global__ void resize_bilinear_pkd_hip_tensor(T *srcPtr,
                                            uint2 srcStridesNH,
                                            T *dstPtr,
                                            uint2 dstStridesNH,
@@ -218,7 +218,7 @@ __global__ void resize_bilinear_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_bilinear_pln_tensor(T *srcPtr,
+__global__ void resize_bilinear_pln_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -267,7 +267,7 @@ __global__ void resize_bilinear_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_bilinear_pkd3_pln3_tensor(T *srcPtr,
+__global__ void resize_bilinear_pkd3_pln3_hip_tensor(T *srcPtr,
                                                  uint2 srcStridesNH,
                                                  T *dstPtr,
                                                  uint3 dstStridesNCH,
@@ -300,7 +300,7 @@ __global__ void resize_bilinear_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_bilinear_pln3_pkd3_tensor(T *srcPtr,
+__global__ void resize_bilinear_pln3_pkd3_hip_tensor(T *srcPtr,
                                                  uint3 srcStridesNCH,
                                                  T *dstPtr,
                                                  uint2 dstStridesNH,
@@ -333,7 +333,7 @@ __global__ void resize_bilinear_pln3_pkd3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_generic_pkd_tensor(T *srcPtr,
+__global__ void resize_generic_pkd_hip_tensor(T *srcPtr,
                                           uint2 srcStridesNH,
                                           T *dstPtr,
                                           uint2 dstStridesNH,
@@ -407,7 +407,7 @@ __global__ void resize_generic_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_generic_pln3_tensor(T *srcPtr,
+__global__ void resize_generic_pln3_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -487,7 +487,7 @@ __global__ void resize_generic_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_generic_pln1_tensor(T *srcPtr,
+__global__ void resize_generic_pln1_hip_tensor(T *srcPtr,
                                            uint3 srcStridesNCH,
                                            T *dstPtr,
                                            uint3 dstStridesNCH,
@@ -559,7 +559,7 @@ __global__ void resize_generic_pln1_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_generic_pkd3_pln3_tensor(T *srcPtr,
+__global__ void resize_generic_pkd3_pln3_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -632,7 +632,7 @@ __global__ void resize_generic_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_generic_pln3_pkd3_tensor(T *srcPtr,
+__global__ void resize_generic_pln3_pkd3_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -737,7 +737,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         int globalThreads_z = handle.GetBatchSize();
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(resize_nearest_neighbor_pkd_tensor,
+            hipLaunchKernelGGL(resize_nearest_neighbor_pkd_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -751,7 +751,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(resize_nearest_neighbor_pln_tensor,
+            hipLaunchKernelGGL(resize_nearest_neighbor_pln_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -768,7 +768,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(resize_nearest_neighbor_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(resize_nearest_neighbor_pkd3_pln3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -783,7 +783,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
                 globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-                hipLaunchKernelGGL(resize_nearest_neighbor_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(resize_nearest_neighbor_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -807,7 +807,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         int globalThreads_z = handle.GetBatchSize();
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(resize_bilinear_pkd_tensor,
+            hipLaunchKernelGGL(resize_bilinear_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -821,7 +821,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(resize_bilinear_pln_tensor,
+            hipLaunchKernelGGL(resize_bilinear_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -838,7 +838,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(resize_bilinear_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(resize_bilinear_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -852,7 +852,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                hipLaunchKernelGGL(resize_bilinear_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(resize_bilinear_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -877,7 +877,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(resize_generic_pkd_tensor,
+            hipLaunchKernelGGL(resize_generic_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -894,7 +894,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         {
             if (srcDescPtr->c == 3)
             {
-                hipLaunchKernelGGL(resize_generic_pln3_tensor,
+                hipLaunchKernelGGL(resize_generic_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -909,7 +909,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
             }
             else if (srcDescPtr->c == 1)
             {
-                hipLaunchKernelGGL(resize_generic_pln1_tensor,
+                hipLaunchKernelGGL(resize_generic_pln1_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -927,7 +927,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(resize_generic_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(resize_generic_pkd3_pln3_hip_tensor,
                                     dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                     dim3(localThreads_x, localThreads_y, localThreads_z),
                                     0,
@@ -942,7 +942,7 @@ RppStatus hip_exec_resize_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                hipLaunchKernelGGL(resize_generic_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(resize_generic_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,

--- a/src/modules/hip/kernel/resize_crop_mirror.hpp
+++ b/src/modules/hip/kernel/resize_crop_mirror.hpp
@@ -44,7 +44,7 @@ __device__ void resize_crop_mirror_roi_and_srclocs_hip_compute_mirror(int4 *srcR
 }
 
 template <typename T>
-__global__ void resize_crop_mirror_bilinear_pkd_tensor(T *srcPtr,
+__global__ void resize_crop_mirror_bilinear_pkd_hip_tensor(T *srcPtr,
                                                        uint2 srcStridesNH,
                                                        T *dstPtr,
                                                        uint2 dstStridesNH,
@@ -80,7 +80,7 @@ __global__ void resize_crop_mirror_bilinear_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_crop_mirror_bilinear_pln_tensor(T *srcPtr,
+__global__ void resize_crop_mirror_bilinear_pln_hip_tensor(T *srcPtr,
                                                        uint3 srcStridesNCH,
                                                        T *dstPtr,
                                                        uint3 dstStridesNCH,
@@ -133,7 +133,7 @@ __global__ void resize_crop_mirror_bilinear_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_crop_mirror_bilinear_pkd3_pln3_tensor(T *srcPtr,
+__global__ void resize_crop_mirror_bilinear_pkd3_pln3_hip_tensor(T *srcPtr,
                                                              uint2 srcStridesNH,
                                                              T *dstPtr,
                                                              uint3 dstStridesNCH,
@@ -169,7 +169,7 @@ __global__ void resize_crop_mirror_bilinear_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void resize_crop_mirror_bilinear_pln3_pkd3_tensor(T *srcPtr,
+__global__ void resize_crop_mirror_bilinear_pln3_pkd3_hip_tensor(T *srcPtr,
                                                              uint3 srcStridesNCH,
                                                              T *dstPtr,
                                                              uint2 dstStridesNH,
@@ -231,7 +231,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(resize_crop_mirror_bilinear_pkd_tensor,
+            hipLaunchKernelGGL(resize_crop_mirror_bilinear_pkd_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -246,7 +246,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(resize_crop_mirror_bilinear_pln_tensor,
+            hipLaunchKernelGGL(resize_crop_mirror_bilinear_pln_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -264,7 +264,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(resize_crop_mirror_bilinear_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(resize_crop_mirror_bilinear_pkd3_pln3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -280,7 +280,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
                 globalThreads_x = (dstDescPtr->w + 7) >> 3;
-                hipLaunchKernelGGL(resize_crop_mirror_bilinear_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(resize_crop_mirror_bilinear_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,

--- a/src/modules/hip/kernel/resize_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/resize_mirror_normalize.hpp
@@ -80,7 +80,7 @@ __device__ void resize_mirror_normalize_roi_and_srclocs_hip_compute_mirror(int4 
 }
 
 template <typename T, typename U>
-__global__ void resize_mirror_normalize_bilinear_pkd_tensor(T *srcPtr,
+__global__ void resize_mirror_normalize_bilinear_pkd_hip_tensor(T *srcPtr,
                                                             uint2 srcStridesNH,
                                                             U *dstPtr,
                                                             uint2 dstStridesNH,
@@ -132,7 +132,7 @@ __global__ void resize_mirror_normalize_bilinear_pkd_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void resize_mirror_normalize_bilinear_pln_tensor(T *srcPtr,
+__global__ void resize_mirror_normalize_bilinear_pln_hip_tensor(T *srcPtr,
                                                             uint3 srcStridesNCH,
                                                             U *dstPtr,
                                                             uint3 dstStridesNCH,
@@ -201,7 +201,7 @@ __global__ void resize_mirror_normalize_bilinear_pln_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void resize_mirror_normalize_bilinear_pkd3_pln3_tensor(T *srcPtr,
+__global__ void resize_mirror_normalize_bilinear_pkd3_pln3_hip_tensor(T *srcPtr,
                                                                   uint2 srcStridesNH,
                                                                   U *dstPtr,
                                                                   uint3 dstStridesNCH,
@@ -253,7 +253,7 @@ __global__ void resize_mirror_normalize_bilinear_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T, typename U>
-__global__ void resize_mirror_normalize_bilinear_pln3_pkd3_tensor(T *srcPtr,
+__global__ void resize_mirror_normalize_bilinear_pln3_pkd3_hip_tensor(T *srcPtr,
                                                                   uint3 srcStridesNCH,
                                                                   U *dstPtr,
                                                                   uint2 dstStridesNH,
@@ -332,7 +332,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pkd_tensor,
+            hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -351,7 +351,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
         {
             if(srcDescPtr->c == 3)
             {
-                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln_tensor,
+                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -369,7 +369,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
             }
             else if(srcDescPtr->c == 1)
             {
-                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln_tensor,
+                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -390,7 +390,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pkd3_pln3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,
@@ -408,7 +408,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
                 globalThreads_x = (dstDescPtr->w + 7) >> 3;
-                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                    dim3(localThreads_x, localThreads_y, localThreads_z),
                                    0,

--- a/src/modules/hip/kernel/spatter.hpp
+++ b/src/modules/hip/kernel/spatter.hpp
@@ -31,7 +31,7 @@ __device__ void spatter_hip_compute(half *srcPtr, d_float8 *src_f8, d_float8 *ds
 }
 
 template <typename T>
-__global__ void spatter_pkd_tensor(T *srcPtr,
+__global__ void spatter_pkd_hip_tensor(T *srcPtr,
                                    uint2 srcStridesNH,
                                    T *dstPtr,
                                    uint2 dstStridesNH,
@@ -72,7 +72,7 @@ __global__ void spatter_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void spatter_pln_tensor(T *srcPtr,
+__global__ void spatter_pln_hip_tensor(T *srcPtr,
                                    uint3 srcStridesNCH,
                                    T *dstPtr,
                                    uint3 dstStridesNCH,
@@ -129,7 +129,7 @@ __global__ void spatter_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void spatter_pkd3_pln3_tensor(T *srcPtr,
+__global__ void spatter_pkd3_pln3_hip_tensor(T *srcPtr,
                                          uint2 srcStridesNH,
                                          T *dstPtr,
                                          uint3 dstStridesNCH,
@@ -170,7 +170,7 @@ __global__ void spatter_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void spatter_pln3_pkd3_tensor(T *srcPtr,
+__global__ void spatter_pln3_pkd3_hip_tensor(T *srcPtr,
                                          uint3 srcStridesNCH,
                                          T *dstPtr,
                                          uint2 dstStridesNH,
@@ -252,7 +252,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-        hipLaunchKernelGGL(spatter_pkd_tensor,
+        hipLaunchKernelGGL(spatter_pkd_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -270,7 +270,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
-        hipLaunchKernelGGL(spatter_pln_tensor,
+        hipLaunchKernelGGL(spatter_pln_hip_tensor,
                            dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                            dim3(localThreads_x, localThreads_y, localThreads_z),
                            0,
@@ -291,7 +291,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(spatter_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(spatter_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -310,7 +310,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(spatter_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(spatter_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/swap_channels.hpp
+++ b/src/modules/hip/kernel/swap_channels.hpp
@@ -11,7 +11,7 @@ __device__ void swap_channels_hip_compute(d_float24 *pix_f24)
 }
 
 template <typename T>
-__global__ void swap_channels_pkd_tensor(T *srcPtr,
+__global__ void swap_channels_pkd_hip_tensor(T *srcPtr,
                                          uint2 srcStridesNH,
                                          T *dstPtr,
                                          uint2 dstStridesNH,
@@ -37,7 +37,7 @@ __global__ void swap_channels_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void swap_channels_pln_tensor(T *srcPtr,
+__global__ void swap_channels_pln_hip_tensor(T *srcPtr,
                                          uint3 srcStridesNCH,
                                          T *dstPtr,
                                          uint3 dstStridesNCH,
@@ -63,7 +63,7 @@ __global__ void swap_channels_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void swap_channels_pkd3_pln3_tensor(T *srcPtr,
+__global__ void swap_channels_pkd3_pln3_hip_tensor(T *srcPtr,
                                                uint2 srcStridesNH,
                                                T *dstPtr,
                                                uint3 dstStridesNCH,
@@ -89,7 +89,7 @@ __global__ void swap_channels_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void swap_channels_pln3_pkd3_tensor(T *srcPtr,
+__global__ void swap_channels_pln3_pkd3_hip_tensor(T *srcPtr,
                                                uint3 srcStridesNCH,
                                                T *dstPtr,
                                                uint2 dstStridesNH,
@@ -133,7 +133,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (dstDescPtr->strides.hStride / 3 + 7) >> 3;
-            hipLaunchKernelGGL(swap_channels_pkd_tensor,
+            hipLaunchKernelGGL(swap_channels_pkd_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -146,7 +146,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(swap_channels_pln_tensor,
+            hipLaunchKernelGGL(swap_channels_pln_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -159,7 +159,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(swap_channels_pkd3_pln3_tensor,
+            hipLaunchKernelGGL(swap_channels_pkd3_pln3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,
@@ -173,7 +173,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-            hipLaunchKernelGGL(swap_channels_pln3_pkd3_tensor,
+            hipLaunchKernelGGL(swap_channels_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                dim3(localThreads_x, localThreads_y, localThreads_z),
                                0,

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -30,7 +30,7 @@ __device__ void warp_affine_roi_and_srclocs_hip_compute(int4 *srcRoiPtr_i4, int 
 // -------------------- Set 1 - Bilinear Interpolation --------------------
 
 template <typename T>
-__global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
+__global__ void warp_affine_bilinear_pkd_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -61,7 +61,7 @@ __global__ void warp_affine_bilinear_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
+__global__ void warp_affine_bilinear_pln_hip_tensor(T *srcPtr,
                                                 uint3 srcStridesNCH,
                                                 T *dstPtr,
                                                 uint3 dstStridesNCH,
@@ -108,7 +108,7 @@ __global__ void warp_affine_bilinear_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
+__global__ void warp_affine_bilinear_pkd3_pln3_hip_tensor(T *srcPtr,
                                                       uint2 srcStridesNH,
                                                       T *dstPtr,
                                                       uint3 dstStridesNCH,
@@ -139,7 +139,7 @@ __global__ void warp_affine_bilinear_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
+__global__ void warp_affine_bilinear_pln3_pkd3_hip_tensor(T *srcPtr,
                                                       uint3 srcStridesNCH,
                                                       T *dstPtr,
                                                       uint2 dstStridesNH,
@@ -172,7 +172,7 @@ __global__ void warp_affine_bilinear_pln3_pkd3_tensor(T *srcPtr,
 // -------------------- Set 2 - Nearest Neighbor Interpolation --------------------
 
 template <typename T>
-__global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
+__global__ void warp_affine_nearest_neighbor_pkd_hip_tensor(T *srcPtr,
                                                 uint2 srcStridesNH,
                                                 T *dstPtr,
                                                 uint2 dstStridesNH,
@@ -203,7 +203,7 @@ __global__ void warp_affine_nearest_neighbor_pkd_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
+__global__ void warp_affine_nearest_neighbor_pln_hip_tensor(T *srcPtr,
                                                         uint3 srcStridesNCH,
                                                         T *dstPtr,
                                                         uint3 dstStridesNCH,
@@ -250,7 +250,7 @@ __global__ void warp_affine_nearest_neighbor_pln_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
+__global__ void warp_affine_nearest_neighbor_pkd3_pln3_hip_tensor(T *srcPtr,
                                                               uint2 srcStridesNH,
                                                               T *dstPtr,
                                                               uint3 dstStridesNCH,
@@ -281,7 +281,7 @@ __global__ void warp_affine_nearest_neighbor_pkd3_pln3_tensor(T *srcPtr,
 }
 
 template <typename T>
-__global__ void warp_affine_nearest_neighbor_pln3_pkd3_tensor(T *srcPtr,
+__global__ void warp_affine_nearest_neighbor_pln3_pkd3_hip_tensor(T *srcPtr,
                                                               uint3 srcStridesNCH,
                                                               T *dstPtr,
                                                               uint2 dstStridesNH,
@@ -341,7 +341,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(warp_affine_bilinear_pkd_tensor,
+            hipLaunchKernelGGL(warp_affine_bilinear_pkd_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -356,7 +356,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(warp_affine_bilinear_pln_tensor,
+            hipLaunchKernelGGL(warp_affine_bilinear_pln_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -374,7 +374,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(warp_affine_bilinear_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(warp_affine_bilinear_pkd3_pln3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -390,7 +390,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
                 globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-                hipLaunchKernelGGL(warp_affine_bilinear_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(warp_affine_bilinear_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -409,7 +409,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
     {
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd_tensor,
+            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -424,7 +424,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NCHW))
         {
-            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln_tensor,
+            hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln_hip_tensor,
                             dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                             dim3(localThreads_x, localThreads_y, localThreads_z),
                             0,
@@ -442,7 +442,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
         {
             if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
             {
-                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd3_pln3_tensor,
+                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pkd3_pln3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,
@@ -458,7 +458,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
                 globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
-                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln3_pkd3_tensor,
+                hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                                 dim3(localThreads_x, localThreads_y, localThreads_z),
                                 0,


### PR DESCRIPTION
@rrawther All host tensor kernels are already named "_host_tensor". 
This PR changes all tensor hip kernels to be named "_hip_tensor".
