### PR TITLE
Add codeowners for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Documentation files
+docs/* @saadrahim @LisaDelaney
+*.md  @saadrahim @LisaDelaney
+*.rst  @saadrahim @LisaDelaney
+# Header directory
+library/include/*  @saadrahim @LisaDelaney

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==0.21.0
+rocm-docs-core==0.22.0

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==0.22.0
+rocm-docs-core==0.24.0

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -92,7 +92,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.21.0
+rocm-docs-core==0.22.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb

--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -92,7 +92,7 @@ requests==2.28.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.22.0
+rocm-docs-core==0.24.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
Adding code owners for documentation. Plan is to add mandatory reviews from this group of code owners to merge any documentation changes. The header directory is related to documentation and thus changes to that are also flagged for documentation review.