### PR TITLE
Test Package - Add cmake deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,8 +473,8 @@ set(RPP_DEBIAN_PACKAGE_LIST  "hip-runtime-amd, openmp-extras-runtime")
 set(RPP_RPM_PACKAGE_LIST     "hip-runtime-amd, openmp-extras-runtime")
 set(RPP_DEBIAN_DEV_PACKAGE_LIST  "hip-dev, openmp-extras-dev, half")
 set(RPP_RPM_DEV_PACKAGE_LIST     "hip-devel, openmp-extras-devel, half")
-set(RPP_DEBIAN_TEST_PACKAGE_LIST  "python3-dev, python3-pip, python3-pandas, python3-openpyxl, libopencv-dev, libsndfile1-dev")
-set(RPP_RPM_TEST_PACKAGE_LIST     "python3-devel, python3-pip") # TBD: pandas, openpyxl, OpenCV & libsnd packages missing on RPM
+set(RPP_DEBIAN_TEST_PACKAGE_LIST  "cmake, python3-dev, python3-pip, python3-pandas, python3-openpyxl, libopencv-dev, libsndfile1-dev")
+set(RPP_RPM_TEST_PACKAGE_LIST     "cmake, python3-devel, python3-pip") # TBD: pandas, openpyxl, OpenCV & libsnd packages missing on RPM
 
 # Add OS specific dependencies
 if(EXISTS "/etc/os-release")

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ All notable changes for each release are added to our [changelog](CHANGELOG.md).
 * Linux distribution
   * Ubuntu - `22.04` / `24.04`
   * RedHat - `8` / `9`
-  * SLES - `15-SP5`
+  * SLES - `15 SP7`
 * ROCm: rocm-core - `7.0.0`+
 * CMake - Version `3.10`+
 * AMD Clang++ - Version `18.0.0`+

--- a/utilities/test_suite/README.md
+++ b/utilities/test_suite/README.md
@@ -4,6 +4,11 @@ This repository contains four test suites for the RPP library: `image`/`voxel`/`
 
 ## Prerequisites
 
+* CMake Version `3.10` or later
+  ```shell
+  sudo apt install cmake
+  ```
+
 * Turbo JPEG
   ```shell
   sudo apt-get install libturbojpeg0-dev


### PR DESCRIPTION
## Motivation

CTests requires cmake -- Fix for issue #604 

## Technical Details

Clean install of ROCm requires cmake installed prior running the tests

## Test Plan

CTests

## Test Result

CTests should pass without installing cmake manually

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
