### PR TITLE
CP - Remove Meta Package dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,10 +469,10 @@ if(DEFINED ENV{ROCM_LIBPATCH_VERSION})
 endif()
 
 # Set the dependent packages
-set(RPP_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, openmp-extras-runtime")
-set(RPP_RPM_PACKAGE_LIST     "rocm-hip-runtime, openmp-extras-runtime")
-set(RPP_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, openmp-extras-dev, half")
-set(RPP_RPM_DEV_PACKAGE_LIST     "rocm-hip-runtime-devel, openmp-extras-devel, half")
+set(RPP_DEBIAN_PACKAGE_LIST  "hip-runtime-amd, openmp-extras-runtime")
+set(RPP_RPM_PACKAGE_LIST     "hip-runtime-amd, openmp-extras-runtime")
+set(RPP_DEBIAN_DEV_PACKAGE_LIST  "hip-dev, openmp-extras-dev, half")
+set(RPP_RPM_DEV_PACKAGE_LIST     "hip-devel, openmp-extras-devel, half")
 set(RPP_DEBIAN_TEST_PACKAGE_LIST  "python3-dev, python3-pip, python3-pandas, python3-openpyxl, libopencv-dev, libsndfile1-dev")
 set(RPP_RPM_TEST_PACKAGE_LIST     "python3-devel, python3-pip") # TBD: pandas, openpyxl, OpenCV & libsnd packages missing on RPM
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Spectrogram kernel output represented as a image <br><br>
   ```
 * HIP
   ```shell
-  sudo apt install rocm-hip-runtime-dev
+  sudo apt install hip-dev
   ```
 
 * OpenMP


### PR DESCRIPTION
## Motivation

To remove Meta Package Dependency for RPP ((to meta package rocm-hip-runtime))
Cherry Pick of https://github.com/ROCm/rpp/pull/610 to Release

## Technical Details

- Dependency to be updated to the level of individual packages

## Test Plan

Verify Build, Package Dependencies

## Test Result
https://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb/compute-rocm-dkms-component-baas-1906/
https://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb/compute-rocm-dkms-component-baas-1961/
Mainline - 16741
dpkg -I rpp_2.1.0.70100-crdnnh.16741~22.04_amd64.deb
 Depends:  hip-runtime-amd, openmp-extras-runtime

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
