### PR TITLE
Add header location

### DIFF
--- a/src/include/common/cpu/rpp_cpu_batchpd.hpp
+++ b/src/include/common/cpu/rpp_cpu_batchpd.hpp
@@ -30,7 +30,11 @@ SOFTWARE.
 #include <typeinfo>
 #include <cstring>
 #include <omp.h>
-#include <half/half.hpp>
+#if __has_include(<half/half.hpp>)
+    #include <half/half.hpp>
+#else
+    #include <half.hpp>
+#endif
 using halfhpp = half_float::half;
 typedef halfhpp Rpp16f;
 #include "rppdefs.h"

--- a/src/include/common/op_kernel_args.hpp
+++ b/src/include/common/op_kernel_args.hpp
@@ -26,7 +26,11 @@ SOFTWARE.
 
 #include <type_traits>
 #include <cstdint>
-#include <half/half.hpp>
+#if __has_include(<half/half.hpp>)
+    #include <half/half.hpp>
+#else
+    #include <half.hpp>
+#endif
 
 struct OpKernelArg
 {


### PR DESCRIPTION
Following up on #576, these two additional files needed the same fix on Debian after enabling OCL and HOST backends.