### PR TITLE
Update RPP patch version to fix MIVisionX build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/rpp/en/latest](https://rocm.docs.amd.com/projects/rpp/en/latest)
 
 ## (Unreleased) RPP 2.2.2
-* Updating RPP version for gaussian noise kernel API changes
-
-## RPP 2.2.1 for ROCm 7.2.0
 
 ### Added
 * HOST and HIP - pinned buffers API support
@@ -13,6 +10,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 ### Changed
 * CXX Compiler: AMDClang++ - Use compiler core location `${ROCM_PATH}/lib/llvm/bin`
 * Mem Copy eliminated - Helper functions responsible for these copies copy_param_float(), copy_param_uint() have been removed and buffers now consistently use pinned/HIP memory
+* Updating RPP version for gaussian noise kernel API changes
 
 ### Resolved issues
 * Test Suite - Error Code Capture updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/rpp/en/latest](https://rocm.docs.amd.com/projects/rpp/en/latest)
 
+## (Unreleased) RPP 2.2.2
+* Updating RPP version for gaussian noise kernel API changes
+
 ## RPP 2.2.1 for ROCm 7.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/rpp/en/latest](https://rocm.docs.amd.com/projects/rpp/en/latest)
 
+
 ## (Unreleased) RPP 2.2.2
+
+### Added
+
+
+### Changed
+* Updating RPP version for gaussian noise kernel API changes
+
+### Resolved issues
+
+## RPP 2.2.1 for ROCm 7.2.0
 
 ### Added
 * HOST and HIP - pinned buffers API support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 ### Changed
 * CXX Compiler: AMDClang++ - Use compiler core location `${ROCM_PATH}/lib/llvm/bin`
 * Mem Copy eliminated - Helper functions responsible for these copies copy_param_float(), copy_param_uint() have been removed and buffers now consistently use pinned/HIP memory
-* Updating RPP version for gaussian noise kernel API changes
 
 ### Resolved issues
 * Test Suite - Error Code Capture updates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 # RPP Version
 # NOTE: package version and rpp_version.h is generated with this version
-set(VERSION "2.2.1")
+set(VERSION "2.2.2")
 
 # Set Project Version and Language
 project(rpp VERSION ${VERSION} LANGUAGES CXX)


### PR DESCRIPTION
This PR updates the RPP patch version to resolve build errors observed in MIVisionX.