### PR TITLE
Fix - Address RPP -Wall warnings (Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,19 +152,11 @@ endif()
 # Enable -Wall warnings for both release and debug builds
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-# These are warning categories that are not yet cleaned up in source (phase 2+).
-# TODO: Remove these warnings as they are addressed in the following phases. Once done, remove this block
-# and enable -Werror to ensure all warnings are treated as errors.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-function")
-
 # Clang-specific warnings
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # These warnings are suppressed since we are always using a Clang compiler, which supports VLA.
+    # TBD: Determine if we must remove this flag later for standard compliance.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-vla-cxx-extension")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sometimes-uninitialized")
 endif()
 
 message("-- ${BoldBlue}AMD RPP Build Type -- ${CMAKE_BUILD_TYPE}${ColourReset}")

--- a/src/include/common/cpu/rpp_cpu_common.hpp
+++ b/src/include/common/cpu/rpp_cpu_common.hpp
@@ -175,6 +175,30 @@ inline void compute_ltrb_from_xywh_host(RpptROIPtr roiPtrInput, RpptROIPtr roiPt
     roiPtrImage->ltrbROI.rb.y = roiPtrInput->xywhROI.xy.y + roiPtrInput->xywhROI.roiHeight - 1;
 }
 
+// Makes a full-tensor default ROI with explicit member assignment.
+inline RpptROI rpp_make_roi_xywh_full(Rpp32s roiWidth, Rpp32s roiHeight)
+{
+    RpptROI roi{};
+    roi.xywhROI.xy.x = 0;
+    roi.xywhROI.xy.y = 0;
+    roi.xywhROI.roiWidth = roiWidth;
+    roi.xywhROI.roiHeight = roiHeight;
+    return roi;
+}
+
+// Makes a full-tensor default ROI3D with explicit member assignment.
+inline RpptROI3D rpp_make_roi3d_xyzwhd_full(Rpp32s roiWidth, Rpp32s roiHeight, Rpp32s roiDepth)
+{
+    RpptROI3D roi{};
+    roi.xyzwhdROI.xyz.x = 0;
+    roi.xyzwhdROI.xyz.y = 0;
+    roi.xyzwhdROI.xyz.z = 0;
+    roi.xyzwhdROI.roiWidth = roiWidth;
+    roi.xyzwhdROI.roiHeight = roiHeight;
+    roi.xyzwhdROI.roiDepth = roiDepth;
+    return roi;
+}
+
 inline void compute_roi_boundary_check_host(RpptROIPtr roiPtrImage, RpptROIPtr roiPtr, RpptROIPtr roiPtrDefault)
 {
     roiPtr->xywhROI.xy.x = std::max(roiPtrDefault->xywhROI.xy.x, roiPtrImage->xywhROI.xy.x);

--- a/src/include/common/hip/rpp_hip_interpolation.hpp
+++ b/src/include/common/hip/rpp_hip_interpolation.hpp
@@ -594,7 +594,6 @@ __device__ __forceinline__ void rpp_hip_interpolate3_nearest_neighbor_pkd3(T *sr
     }
     else
     {
-        uint src;
         int srcIdx = locSrc.y * srcStrideH + locSrc.x * 3;
         rpp_hip_interpolate3_nearest_neighbor_load_pkd3(srcPtr + srcIdx, dst_f3);
     }

--- a/src/include/common/rppt_validate.hpp
+++ b/src/include/common/rppt_validate.hpp
@@ -58,7 +58,7 @@ inline RppLayoutParams get_layout_params(RpptLayout layout, Rpp32u channels)
 
 inline int check_roi_out_of_bounds(RpptROIPtr roiPtrImage, RpptDescPtr srcDescPtr, RpptRoiType type)
 {
-    int x, y, w, h;
+    int x = 0, y = 0, w = 0, h = 0;
     if (type == RpptRoiType::XYWH)
     {
         x = ((0 <= roiPtrImage->xywhROI.xy.x) && (roiPtrImage->xywhROI.xy.x < srcDescPtr->w)) ? roiPtrImage->xywhROI.xy.x : -1;
@@ -72,9 +72,15 @@ inline int check_roi_out_of_bounds(RpptROIPtr roiPtrImage, RpptDescPtr srcDescPt
         y = ((0 <= roiPtrImage->ltrbROI.lt.y) && (roiPtrImage->ltrbROI.lt.y < srcDescPtr->h)) ? roiPtrImage->ltrbROI.lt.y : -1;
         w = ((0 <= roiPtrImage->ltrbROI.rb.x) && (roiPtrImage->ltrbROI.rb.x < srcDescPtr->w)) ? roiPtrImage->ltrbROI.rb.x - roiPtrImage->ltrbROI.lt.x + 1 : -1;
         h = ((0 <= roiPtrImage->ltrbROI.rb.y) && (roiPtrImage->ltrbROI.rb.y < srcDescPtr->h)) ? roiPtrImage->ltrbROI.rb.y - roiPtrImage->ltrbROI.lt.y + 1 : -1;
-    }
-    if ((x < 0) || (y < 0) || (w < 0) || (h < 0))
+    } else {
+        // Invalid ROI type
         return -1;
+    }
+
+    if ((x < 0) || (y < 0) || (w < 0) || (h < 0)) {
+        return -1;
+    }
+    
     return 0;
 }
 

--- a/src/modules/tensor/cpu/kernel/add_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/add_scalar.cpp
@@ -42,9 +42,9 @@ RppStatus add_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/add_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/add_scalar.cpp
@@ -45,10 +45,9 @@ RppStatus add_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/audio_tensor_add_tensor.cpp
+++ b/src/modules/tensor/cpu/kernel/audio_tensor_add_tensor.cpp
@@ -32,10 +32,9 @@ RppStatus audio_tensor_add_tensor_host(Rpp32f *srcPtr1,
                                        Rpp32s *srcLengthTensor,
                                        rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtr1Temp = srcPtr1 + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/audio_tensor_mul_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/audio_tensor_mul_scalar.cpp
@@ -32,13 +32,12 @@ RppStatus audio_tensor_mul_scalar_host(Rpp32f *srcPtr,
                                        Rpp32s *srcLengthTensor,
                                        rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Broadcast the scalar value for SIMD operations
     __m256 pScalar = _mm256_set1_ps(scalarValue);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32u batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/bitwise_and.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_and.cpp
@@ -38,10 +38,9 @@ RppStatus bitwise_and_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/bitwise_and.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_and.cpp
@@ -37,7 +37,7 @@ RppStatus bitwise_and_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/bitwise_not.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_not.cpp
@@ -36,7 +36,7 @@ RppStatus bitwise_not_u8_u8_host_tensor(Rpp8u *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& Handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = Handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/bitwise_not.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_not.cpp
@@ -37,10 +37,9 @@ RppStatus bitwise_not_u8_u8_host_tensor(Rpp8u *srcPtr,
                                         rpp::Handle& Handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = Handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(Handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/bitwise_or.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_or.cpp
@@ -37,7 +37,7 @@ RppStatus bitwise_or_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& Handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = Handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/bitwise_or.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_or.cpp
@@ -38,10 +38,9 @@ RppStatus bitwise_or_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                        rpp::Handle& Handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = Handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(Handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/bitwise_xor.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_xor.cpp
@@ -37,10 +37,9 @@ RppStatus bitwise_xor_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                          rpp::Handle& Handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = Handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(Handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/bitwise_xor.cpp
+++ b/src/modules/tensor/cpu/kernel/bitwise_xor.cpp
@@ -36,7 +36,7 @@ RppStatus bitwise_xor_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& Handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = Handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/blend.cpp
+++ b/src/modules/tensor/cpu/kernel/blend.cpp
@@ -36,10 +36,9 @@ RppStatus blend_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -282,10 +281,9 @@ RppStatus blend_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -507,10 +505,9 @@ RppStatus blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -827,10 +824,9 @@ RppStatus blend_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/blend.cpp
+++ b/src/modules/tensor/cpu/kernel/blend.cpp
@@ -35,7 +35,7 @@ RppStatus blend_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -281,7 +281,7 @@ RppStatus blend_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -506,7 +506,7 @@ RppStatus blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -826,7 +826,7 @@ RppStatus blend_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/box_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/box_filter.cpp
@@ -257,7 +257,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
@@ -1741,7 +1741,7 @@ RppStatus box_filter_float_host_tensor(T *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
@@ -2924,7 +2924,7 @@ RppStatus box_filter_generic_host_tensor(T *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/box_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/box_filter.cpp
@@ -258,7 +258,6 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -271,7 +270,8 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1742,7 +1742,6 @@ RppStatus box_filter_float_host_tensor(T *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -1755,7 +1754,8 @@ RppStatus box_filter_float_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2925,10 +2925,9 @@ RppStatus box_filter_generic_host_tensor(T *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/box_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/box_filter.cpp
@@ -87,7 +87,6 @@ inline void box_filter_generic_tensor(T **srcPtrTemp, T *dstPtrTemp, Rpp32s colu
 
     // find the colKernelLoopLimit based on columnIndex
     get_kernel_loop_limit(columnIndex, columnKernelLoopLimit, padLength, unpaddedWidth);
-    Rpp32s rowStart, rowEnd, colStart, colEnd;
     // Conditions separately handled to avoid branching inside loops
     if((kernelSize != rowKernelLoopLimit) || (kernelSize != columnKernelLoopLimit))
     {
@@ -954,7 +953,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[5], pxRowHalf[2], pxResult;
+                            __m256i pxRow[5], pxRowHalf[2];
                             rpp_load_box_filter_char_5x5_host(pxRow, srcPtrTemp[c], rowKernelLoopLimit, padIndex);
 
                             // pack lower and higher half of each of 5 loaded row values from 8 bit to 16 bit and add
@@ -1152,7 +1151,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[7], pxRowHalf[2], pxResult;
+                            __m256i pxRow[7], pxRowHalf[2];
                             rpp_load_box_filter_char_7x7_host(pxRow, srcPtrTemp[c], rowKernelLoopLimit, padIndex);
 
                             // unpack lower and higher half of each of 7 loaded row values from 8 bit to 16 bit and add
@@ -1477,7 +1476,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                         }
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[4];
+                        __m128i px128[8], pxDst[4];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_add_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 
@@ -1585,7 +1584,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                                 unpack_and_add_host<9>(pxRow, pxRowHalf);
                             }
 
-                            __m128i pxTemp[3], pxDst;
+                            __m128i pxTemp[3];
                             extract_3sse_registers(pxRowHalf, pxTemp);
                             blend_shuffle_add_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[0], pxMaskPln, blendRegisterOrder);
                             blend_shuffle_add_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[1], pxMaskPln, blendRegisterOrder);
@@ -1664,7 +1663,7 @@ RppStatus box_filter_char_host_tensor(T *srcPtr,
                         }
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[4];
+                        __m128i px128[8], pxDst[4];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_add_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 

--- a/src/modules/tensor/cpu/kernel/brightness.cpp
+++ b/src/modules/tensor/cpu/kernel/brightness.cpp
@@ -116,10 +116,9 @@ RppStatus brightness_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -330,10 +329,9 @@ RppStatus brightness_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -562,10 +560,9 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -832,10 +829,9 @@ RppStatus brightness_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/brightness.cpp
+++ b/src/modules/tensor/cpu/kernel/brightness.cpp
@@ -115,7 +115,7 @@ RppStatus brightness_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -329,7 +329,7 @@ RppStatus brightness_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -561,7 +561,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -831,7 +831,7 @@ RppStatus brightness_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/channel_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/channel_dropout.cpp
@@ -36,10 +36,9 @@ RppStatus channel_dropout_host_tensor(T *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/channel_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/channel_dropout.cpp
@@ -35,7 +35,7 @@ RppStatus channel_dropout_host_tensor(T *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/channel_permute.cpp
+++ b/src/modules/tensor/cpu/kernel/channel_permute.cpp
@@ -93,7 +93,7 @@ RppStatus channel_permute_u8_u8_host_tensor(Rpp8u *srcPtr,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    __m256i p[6], pPermute[6];
+                    __m256i p[6];
                     rpp_simd_load(rpp_load96_u8pkd3_to_u8pln3, srcPtrTemp, p);    // simd loads
                     rpp_simd_store(rpp_store96_u8pln3_to_u8pln3, dstPtrTemp[permutationOrder[0]], dstPtrTemp[permutationOrder[1]], dstPtrTemp[permutationOrder[2]], p);    // simd stores with channel permute
                     srcPtrTemp += vectorIncrement;
@@ -308,7 +308,7 @@ RppStatus channel_permute_f32_f32_host_tensor(Rpp32f *srcPtr,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    __m256 p[3], pPermute[3];
+                    __m256 p[3];
                     rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTemp[permutationOrder[0]], dstPtrTemp[permutationOrder[1]], dstPtrTemp[permutationOrder[2]], p);    // simd stores with channel permute
                     srcPtrTemp += vectorIncrement;
@@ -525,7 +525,7 @@ RppStatus channel_permute_f16_f16_host_tensor(Rpp16f *srcPtr,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    __m256 p[3], pPermute[3];
+                    __m256 p[3];
                     rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTemp[permutationOrder[0]], dstPtrTemp[permutationOrder[1]], dstPtrTemp[permutationOrder[2]], p);    // simd stores with channel permute
                     srcPtrTemp += vectorIncrement;
@@ -742,7 +742,7 @@ RppStatus channel_permute_i8_i8_host_tensor(Rpp8s *srcPtr,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    __m256 p[6], pPermute[6];
+                    __m256 p[6];
                     rpp_simd_load(rpp_load48_i8pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     rpp_simd_store(rpp_store48_f32pln3_to_i8pln3_avx, dstPtrTemp[permutationOrder[0]], dstPtrTemp[permutationOrder[1]], dstPtrTemp[permutationOrder[2]], p);    // simd stores with channel permute
                     srcPtrTemp += vectorIncrement;

--- a/src/modules/tensor/cpu/kernel/channel_permute.cpp
+++ b/src/modules/tensor/cpu/kernel/channel_permute.cpp
@@ -54,10 +54,9 @@ RppStatus channel_permute_u8_u8_host_tensor(Rpp8u *srcPtr,
                                             RppLayoutParams layoutParams,
                                             rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp8u *srcPtrImage, *dstPtrImage;
@@ -269,10 +268,9 @@ RppStatus channel_permute_f32_f32_host_tensor(Rpp32f *srcPtr,
                                               RppLayoutParams layoutParams,
                                               rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrImage, *dstPtrImage;
@@ -487,10 +485,9 @@ RppStatus channel_permute_f16_f16_host_tensor(Rpp16f *srcPtr,
                                               RppLayoutParams layoutParams,
                                               rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp16f *srcPtrImage, *dstPtrImage;
@@ -705,10 +702,9 @@ RppStatus channel_permute_i8_i8_host_tensor(Rpp8s *srcPtr,
                                             RppLayoutParams layoutParams,
                                             rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp8s *srcPtrImage, *dstPtrImage;

--- a/src/modules/tensor/cpu/kernel/coarse_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/coarse_dropout.cpp
@@ -37,7 +37,7 @@ RppStatus coarse_dropout_host_tensor(T *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/coarse_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/coarse_dropout.cpp
@@ -38,10 +38,10 @@ RppStatus coarse_dropout_host_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/color_cast.cpp
+++ b/src/modules/tensor/cpu/kernel/color_cast.cpp
@@ -65,7 +65,7 @@ RppStatus color_cast_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -320,7 +320,7 @@ RppStatus color_cast_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -583,7 +583,7 @@ RppStatus color_cast_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -938,7 +938,7 @@ RppStatus color_cast_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/color_cast.cpp
+++ b/src/modules/tensor/cpu/kernel/color_cast.cpp
@@ -66,10 +66,9 @@ RppStatus color_cast_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -321,10 +320,9 @@ RppStatus color_cast_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -584,10 +582,9 @@ RppStatus color_cast_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -939,10 +936,9 @@ RppStatus color_cast_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/color_jitter.cpp
+++ b/src/modules/tensor/cpu/kernel/color_jitter.cpp
@@ -122,10 +122,9 @@ RppStatus color_jitter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -382,10 +381,9 @@ RppStatus color_jitter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -650,10 +648,9 @@ RppStatus color_jitter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1010,10 +1007,9 @@ RppStatus color_jitter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/color_jitter.cpp
+++ b/src/modules/tensor/cpu/kernel/color_jitter.cpp
@@ -121,7 +121,7 @@ RppStatus color_jitter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -381,7 +381,7 @@ RppStatus color_jitter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -649,7 +649,7 @@ RppStatus color_jitter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1009,7 +1009,7 @@ RppStatus color_jitter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/color_temperature.cpp
+++ b/src/modules/tensor/cpu/kernel/color_temperature.cpp
@@ -49,7 +49,7 @@ RppStatus color_temperature_u8_u8_host_tensor(Rpp8u *srcPtr,
                                               RpptRoiType roiType,
                                               RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -288,7 +288,7 @@ RppStatus color_temperature_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                 RpptRoiType roiType,
                                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -531,7 +531,7 @@ RppStatus color_temperature_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                 RpptRoiType roiType,
                                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -775,7 +775,7 @@ RppStatus color_temperature_i8_i8_host_tensor(Rpp8s *srcPtr,
                                               RpptRoiType roiType,
                                               RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)

--- a/src/modules/tensor/cpu/kernel/color_to_greyscale.cpp
+++ b/src/modules/tensor/cpu/kernel/color_to_greyscale.cpp
@@ -56,9 +56,9 @@ RppStatus color_to_greyscale_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp8u *srcPtrImage, *dstPtrImage;
@@ -189,9 +189,9 @@ RppStatus color_to_greyscale_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                  RppLayoutParams layoutParams,
                                                  rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrImage, *dstPtrImage;
@@ -326,9 +326,9 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                  RppLayoutParams layoutParams,
                                                  rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp16f *srcPtrImage, *dstPtrImage;
@@ -483,9 +483,9 @@ RppStatus color_to_greyscale_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         Rpp8s *srcPtrImage, *dstPtrImage;

--- a/src/modules/tensor/cpu/kernel/color_twist.cpp
+++ b/src/modules/tensor/cpu/kernel/color_twist.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 inline void compute_color_twist_24_host(__m256 &pVecR, __m256 &pVecG, __m256 &pVecB, __m256 *pColorTwistParams)
 {
-    __m256 pA, pH, pS, pV, pAdd;
+    __m256 pH, pS, pV, pAdd;
 
     // RGB to HSV
     rgb_to_hsv(pVecR, pVecG, pVecB, pH, pS, pV, pAdd);

--- a/src/modules/tensor/cpu/kernel/color_twist.cpp
+++ b/src/modules/tensor/cpu/kernel/color_twist.cpp
@@ -111,10 +111,9 @@ RppStatus color_twist_u8_u8_host_tensor(Rpp8u *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -439,10 +438,9 @@ RppStatus color_twist_f32_f32_host_tensor(Rpp32f *srcPtr,
                                           rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -763,10 +761,9 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                                           rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1133,10 +1130,9 @@ RppStatus color_twist_i8_i8_host_tensor(Rpp8s *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/color_twist.cpp
+++ b/src/modules/tensor/cpu/kernel/color_twist.cpp
@@ -110,7 +110,7 @@ RppStatus color_twist_u8_u8_host_tensor(Rpp8u *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -438,7 +438,7 @@ RppStatus color_twist_f32_f32_host_tensor(Rpp32f *srcPtr,
                                           RppLayoutParams layoutParams,
                                           rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -762,7 +762,7 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                                           RppLayoutParams layoutParams,
                                           rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1132,7 +1132,7 @@ RppStatus color_twist_i8_i8_host_tensor(Rpp8s *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/concat.cpp
+++ b/src/modules/tensor/cpu/kernel/concat.cpp
@@ -380,7 +380,6 @@ RppStatus concat_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = srcPtr1GenericDescPtr->numDims - 1;  // Ignoring batchSize here to get tensor dimensions.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -418,7 +417,8 @@ RppStatus concat_f32_f32_host_tensor(Rpp32f *srcPtr1,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
 	{
         Rpp32u *roi1 = roiTensorSrc1 + batchCount * tensorDims * 2;
@@ -490,7 +490,6 @@ RppStatus concat_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = srcPtr1GenericDescPtr->numDims - 1;  // Ignoring batchSize here to get tensor dimensions.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -528,7 +527,8 @@ RppStatus concat_u8_u8_host_tensor(Rpp8u *srcPtr1,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
 	{
         Rpp32u *roi1 = roiTensorSrc1 + batchCount * tensorDims * 2;
@@ -602,7 +602,6 @@ RppStatus concat_generic_host_tensor(T1 *srcPtr1,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = srcPtr1GenericDescPtr->numDims - 1; // Ignoring batchSize here to get tensor dimensions.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -640,7 +639,8 @@ RppStatus concat_generic_host_tensor(T1 *srcPtr1,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
 	{
         Rpp32u *roi1 = roiTensorSrc1 + batchCount * tensorDims * 2;

--- a/src/modules/tensor/cpu/kernel/contrast.cpp
+++ b/src/modules/tensor/cpu/kernel/contrast.cpp
@@ -64,10 +64,9 @@ RppStatus contrast_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -251,10 +250,9 @@ RppStatus contrast_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -445,10 +443,9 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -640,10 +637,9 @@ RppStatus contrast_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/contrast.cpp
+++ b/src/modules/tensor/cpu/kernel/contrast.cpp
@@ -63,7 +63,7 @@ RppStatus contrast_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -250,7 +250,7 @@ RppStatus contrast_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -444,7 +444,7 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -639,7 +639,7 @@ RppStatus contrast_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/copy.cpp
+++ b/src/modules/tensor/cpu/kernel/copy.cpp
@@ -31,13 +31,12 @@ RppStatus copy_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Copy without fused output-layout toggle (NHWC -> NHWC or NCHW -> NCHW)
     if ((srcDescPtr->c == 1) || (srcDescPtr->layout == dstDescPtr->layout))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8u *srcPtrImage, *dstPtrImage;
@@ -51,7 +50,8 @@ RppStatus copy_u8_u8_host_tensor(Rpp8u *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8u *srcPtrImage, *dstPtrImage;
@@ -106,7 +106,8 @@ RppStatus copy_u8_u8_host_tensor(Rpp8u *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8u *srcPtrImage, *dstPtrImage;
@@ -167,13 +168,12 @@ RppStatus copy_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Copy without fused output-layout toggle (NHWC -> NHWC or NCHW -> NCHW)
     if ((srcDescPtr->c == 1) || (srcDescPtr->layout == dstDescPtr->layout))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp32f *srcPtrImage, *dstPtrImage;
@@ -187,7 +187,8 @@ RppStatus copy_f32_f32_host_tensor(Rpp32f *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp32f *srcPtrImage, *dstPtrImage;
@@ -243,7 +244,8 @@ RppStatus copy_f32_f32_host_tensor(Rpp32f *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp32f *srcPtrImage, *dstPtrImage;
@@ -305,13 +307,12 @@ RppStatus copy_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Copy without fused output-layout toggle (NHWC -> NHWC or NCHW -> NCHW)
     if ((srcDescPtr->c == 1) || (srcDescPtr->layout == dstDescPtr->layout))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp16f *srcPtrImage, *dstPtrImage;
@@ -325,7 +326,8 @@ RppStatus copy_f16_f16_host_tensor(Rpp16f *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp16f *srcPtrImage, *dstPtrImage;
@@ -409,7 +411,8 @@ RppStatus copy_f16_f16_host_tensor(Rpp16f *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp16f *srcPtrImage, *dstPtrImage;
@@ -499,13 +502,12 @@ RppStatus copy_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Copy without fused output-layout toggle (NHWC -> NHWC or NCHW -> NCHW)
     if ((srcDescPtr->c == 1) || (srcDescPtr->layout == dstDescPtr->layout))
     {
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8s *srcPtrImage, *dstPtrImage;
@@ -519,7 +521,8 @@ RppStatus copy_i8_i8_host_tensor(Rpp8s *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8s *srcPtrImage, *dstPtrImage;
@@ -574,7 +577,8 @@ RppStatus copy_i8_i8_host_tensor(Rpp8s *srcPtr,
     else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
     {
         omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+        omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
         for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
         {
             Rpp8s *srcPtrImage, *dstPtrImage;

--- a/src/modules/tensor/cpu/kernel/crop.cpp
+++ b/src/modules/tensor/cpu/kernel/crop.cpp
@@ -33,7 +33,7 @@ RppStatus crop_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -184,7 +184,7 @@ RppStatus crop_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -337,7 +337,7 @@ RppStatus crop_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -539,7 +539,7 @@ RppStatus crop_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/crop.cpp
+++ b/src/modules/tensor/cpu/kernel/crop.cpp
@@ -34,10 +34,9 @@ RppStatus crop_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -185,10 +184,9 @@ RppStatus crop_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -338,10 +336,9 @@ RppStatus crop_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -540,10 +537,9 @@ RppStatus crop_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/crop_and_patch.cpp
+++ b/src/modules/tensor/cpu/kernel/crop_and_patch.cpp
@@ -37,10 +37,9 @@ RppStatus crop_and_patch_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -391,10 +390,9 @@ RppStatus crop_and_patch_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -751,10 +749,9 @@ RppStatus crop_and_patch_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1228,10 +1225,9 @@ RppStatus crop_and_patch_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/crop_and_patch.cpp
+++ b/src/modules/tensor/cpu/kernel/crop_and_patch.cpp
@@ -36,7 +36,7 @@ RppStatus crop_and_patch_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -390,7 +390,7 @@ RppStatus crop_and_patch_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -750,7 +750,7 @@ RppStatus crop_and_patch_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1227,7 +1227,7 @@ RppStatus crop_and_patch_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
@@ -77,10 +77,9 @@ RppStatus crop_mirror_normalize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -497,10 +496,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -917,10 +915,9 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1346,10 +1343,9 @@ RppStatus crop_mirror_normalize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1766,10 +1762,9 @@ RppStatus crop_mirror_normalize_u8_f32_host_tensor(Rpp8u *srcPtr,
                                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2214,10 +2209,9 @@ RppStatus crop_mirror_normalize_u8_f16_host_tensor(Rpp8u *srcPtr,
                                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
@@ -76,7 +76,7 @@ RppStatus crop_mirror_normalize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                   RppLayoutParams layoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -496,7 +496,7 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -916,7 +916,7 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1345,7 +1345,7 @@ RppStatus crop_mirror_normalize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                   RppLayoutParams layoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1765,7 +1765,7 @@ RppStatus crop_mirror_normalize_u8_f32_host_tensor(Rpp8u *srcPtr,
                                                    RppLayoutParams layoutParams,
                                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -2213,7 +2213,7 @@ RppStatus crop_mirror_normalize_u8_f16_host_tensor(Rpp8u *srcPtr,
                                                    RppLayoutParams layoutParams,
                                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/dilate.cpp
+++ b/src/modules/tensor/cpu/kernel/dilate.cpp
@@ -825,7 +825,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[5], pxRowHalf[2], pxResult;
+                            __m256i pxRow[5], pxRowHalf[2];
                             rpp_morphological_load_NxN<5, T, MorphPad_Dilate>(pxRow, srcPtrTemp[c], rowKernelLoopLimit);
 
                             // unpack lower and higher half of each of 5 loaded row values from 8 bit to 16 bit and max
@@ -1014,7 +1014,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[7], pxRowHalf[2], pxResult;
+                            __m256i pxRow[7], pxRowHalf[2];
                             rpp_morphological_load_NxN<7, T, MorphPad_Dilate>(pxRow, srcPtrTemp[c], rowKernelLoopLimit);
 
                             // unpack lower and higher half of each of 7 loaded row values from 8 bit to 16 bit and max
@@ -1318,7 +1318,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                             unpack_and_max_host<9>(pxRow, pxRowHalf);
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[2];
+                        __m128i px128[8], pxDst[2];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_max_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 
@@ -1414,7 +1414,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                             else
                                 unpack_and_max_host<9>(pxRow, pxRowHalf);
 
-                            __m128i pxTemp[3], pxDst;
+                            __m128i pxTemp[3];
                             extract_3sse_registers(pxRowHalf, pxTemp);
                             blend_shuffle_max_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[0], pxMaskPln, blendRegisterOrder);
                             blend_shuffle_max_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[1], pxMaskPln, blendRegisterOrder);
@@ -1492,7 +1492,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                             unpack_and_max_host<9>(pxRow, pxRowHalf);
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[2];
+                        __m128i px128[8], pxDst[2];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_max_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 

--- a/src/modules/tensor/cpu/kernel/dilate.cpp
+++ b/src/modules/tensor/cpu/kernel/dilate.cpp
@@ -177,7 +177,6 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -190,7 +189,8 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1569,7 +1569,6 @@ RppStatus dilate_float_host_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -1582,7 +1581,8 @@ RppStatus dilate_float_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2702,10 +2702,9 @@ RppStatus dilate_generic_host_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/dilate.cpp
+++ b/src/modules/tensor/cpu/kernel/dilate.cpp
@@ -176,7 +176,7 @@ RppStatus dilate_char_host_tensor(T *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
@@ -1568,7 +1568,7 @@ RppStatus dilate_float_host_tensor(T *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
@@ -2701,7 +2701,7 @@ RppStatus dilate_generic_host_tensor(T *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/down_mixing.cpp
+++ b/src/modules/tensor/cpu/kernel/down_mixing.cpp
@@ -33,10 +33,9 @@ RppStatus down_mixing_host_tensor(Rpp32f *srcPtr,
                                   bool normalizeWeights,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/emboss.cpp
+++ b/src/modules/tensor/cpu/kernel/emboss.cpp
@@ -99,7 +99,7 @@ RppStatus emboss_host_tensor(T *srcPtr,
                              RppLayoutParams layoutParams,
                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -1266,7 +1266,7 @@ RppStatus emboss_generic_host_tensor(T *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/emboss.cpp
+++ b/src/modules/tensor/cpu/kernel/emboss.cpp
@@ -100,8 +100,6 @@ RppStatus emboss_host_tensor(T *srcPtr,
                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
         return emboss_generic_host_tensor(srcPtr, srcDescPtr, dstPtr, dstDescPtr, strength, kernelSize, roiTensorPtrSrc, roiType, layoutParams, handle);
 
@@ -111,7 +109,8 @@ RppStatus emboss_host_tensor(T *srcPtr,
     __m256i pxMaskPkd[7] = {avx_pxMaskRotate0To3, avx_pxMaskRotate0To6, avx_pxMaskRotate0To1, avx_pxMaskRotate0To4, avx_pxMaskRotate0To7, avx_pxMaskRotate0To2, avx_pxMaskRotate0To5};
 #endif
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1267,10 +1266,9 @@ RppStatus emboss_generic_host_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/erase.cpp
+++ b/src/modules/tensor/cpu/kernel/erase.cpp
@@ -38,10 +38,9 @@ RppStatus erase_host_tensor(T *srcPtr,
                             rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/erase.cpp
+++ b/src/modules/tensor/cpu/kernel/erase.cpp
@@ -37,7 +37,7 @@ RppStatus erase_host_tensor(T *srcPtr,
                             RppLayoutParams layoutParams,
                             rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/erode.cpp
+++ b/src/modules/tensor/cpu/kernel/erode.cpp
@@ -824,7 +824,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[5], pxRowHalf[2], pxResult;
+                            __m256i pxRow[5], pxRowHalf[2];
                             rpp_morphological_load_NxN<5, T, MorphPad_Erode>(pxRow, srcPtrTemp[c], rowKernelLoopLimit);
 
                             // unpack lower and higher half of each of 5 loaded row values from 8 bit to 16 bit and min
@@ -1012,7 +1012,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                         __m256i pxResultPln[3];
                         for (int c = 0; c < 3; c++)
                         {
-                            __m256i pxRow[7], pxRowHalf[2], pxResult;
+                            __m256i pxRow[7], pxRowHalf[2];
                             rpp_morphological_load_NxN<7, T, MorphPad_Erode>(pxRow, srcPtrTemp[c], rowKernelLoopLimit);
 
                             // unpack lower and higher half of each of 7 loaded row values from 8 bit to 16 bit and min
@@ -1314,7 +1314,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                             unpack_and_min_host<9>(pxRow, pxRowHalf);
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[2];
+                        __m128i px128[8], pxDst[2];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_min_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 
@@ -1410,7 +1410,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                             else
                                 unpack_and_min_host<9>(pxRow, pxRowHalf);
 
-                            __m128i pxTemp[3], pxDst;
+                            __m128i pxTemp[3];
                             extract_3sse_registers(pxRowHalf, pxTemp);
                             blend_shuffle_min_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[0], pxMaskPln, blendRegisterOrder);
                             blend_shuffle_min_9x9_host<1, 3, 7, 15, 31, 63, 127>(&pxTemp[1], pxMaskPln, blendRegisterOrder);
@@ -1488,7 +1488,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                             unpack_and_min_host<9>(pxRow, pxRowHalf);
 
                         // get the accumalated result for first 8 elements
-                        __m128i px128[8], pxTemp[7], pxDst[2];
+                        __m128i px128[8], pxDst[2];
                         extract_4sse_registers(pxRowHalf, &px128[0]);
                         blend_shuffle_min_9x9_host<7, 63, 1, 15, 127, 3, 31>(&px128[0], pxMaskPkd, blendRegisterOrder);
 

--- a/src/modules/tensor/cpu/kernel/erode.cpp
+++ b/src/modules/tensor/cpu/kernel/erode.cpp
@@ -177,7 +177,7 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
@@ -1564,7 +1564,7 @@ RppStatus erode_float_host_tensor(T *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
@@ -2696,7 +2696,7 @@ RppStatus erode_generic_host_tensor(T *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/erode.cpp
+++ b/src/modules/tensor/cpu/kernel/erode.cpp
@@ -178,7 +178,6 @@ RppStatus erode_char_host_tensor(T *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp8u>::value || std::is_same<T, Rpp8s>::value), "T must be Rpp8u or Rpp8s");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -191,7 +190,8 @@ RppStatus erode_char_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1565,7 +1565,6 @@ RppStatus erode_float_host_tensor(T *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
     static_assert((std::is_same<T, Rpp32f>::value || std::is_same<T, Rpp16f>::value), "T must be Rpp32f or Rpp16f");
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -1578,7 +1577,8 @@ RppStatus erode_float_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2697,10 +2697,9 @@ RppStatus erode_generic_host_tensor(T *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/exposure.cpp
+++ b/src/modules/tensor/cpu/kernel/exposure.cpp
@@ -62,7 +62,7 @@ RppStatus exposure_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -248,7 +248,7 @@ RppStatus exposure_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -440,7 +440,7 @@ RppStatus exposure_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -633,7 +633,7 @@ RppStatus exposure_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/exposure.cpp
+++ b/src/modules/tensor/cpu/kernel/exposure.cpp
@@ -63,10 +63,9 @@ RppStatus exposure_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -249,10 +248,9 @@ RppStatus exposure_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -441,10 +439,9 @@ RppStatus exposure_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -634,10 +631,9 @@ RppStatus exposure_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/fisheye.cpp
+++ b/src/modules/tensor/cpu/kernel/fisheye.cpp
@@ -87,7 +87,7 @@ RppStatus fisheye_u8_u8_host_tensor(Rpp8u *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -314,7 +314,7 @@ RppStatus fisheye_f16_f16_host_tensor(Rpp16f *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -542,7 +542,7 @@ RppStatus fisheye_f32_f32_host_tensor(Rpp32f *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -770,7 +770,7 @@ RppStatus fisheye_i8_i8_host_tensor(Rpp8s *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/fisheye.cpp
+++ b/src/modules/tensor/cpu/kernel/fisheye.cpp
@@ -88,10 +88,9 @@ RppStatus fisheye_u8_u8_host_tensor(Rpp8u *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -315,10 +314,9 @@ RppStatus fisheye_f16_f16_host_tensor(Rpp16f *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -543,10 +541,9 @@ RppStatus fisheye_f32_f32_host_tensor(Rpp32f *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -771,10 +768,9 @@ RppStatus fisheye_i8_i8_host_tensor(Rpp8s *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;

--- a/src/modules/tensor/cpu/kernel/flip.cpp
+++ b/src/modules/tensor/cpu/kernel/flip.cpp
@@ -35,7 +35,7 @@ RppStatus flip_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -313,7 +313,7 @@ RppStatus flip_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -597,7 +597,7 @@ RppStatus flip_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -880,7 +880,7 @@ RppStatus flip_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/flip.cpp
+++ b/src/modules/tensor/cpu/kernel/flip.cpp
@@ -36,10 +36,9 @@ RppStatus flip_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -314,10 +313,9 @@ RppStatus flip_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -598,10 +596,9 @@ RppStatus flip_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -881,10 +878,9 @@ RppStatus flip_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/flip_voxel.cpp
+++ b/src/modules/tensor/cpu/kernel/flip_voxel.cpp
@@ -38,9 +38,9 @@ RppStatus flip_voxel_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if (srcGenericDescPtr->layout == RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if (srcGenericDescPtr->layout == RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -234,9 +234,9 @@ RppStatus flip_voxel_u8_u8_host_tensor(Rpp8u *srcPtr,
 {
     RpptROI3D roiDefault;
     if (srcGenericDescPtr->layout == RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if (srcGenericDescPtr->layout == RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/flip_voxel.cpp
+++ b/src/modules/tensor/cpu/kernel/flip_voxel.cpp
@@ -41,10 +41,9 @@ RppStatus flip_voxel_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if (srcGenericDescPtr->layout == RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;
@@ -237,10 +236,9 @@ RppStatus flip_voxel_u8_u8_host_tensor(Rpp8u *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if (srcGenericDescPtr->layout == RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/fog.cpp
+++ b/src/modules/tensor/cpu/kernel/fog.cpp
@@ -101,7 +101,7 @@ RppStatus fog_u8_u8_host_tensor(Rpp8u *srcPtr,
                                 rpp::Handle& handle)
 {
     Rpp32u numThreads = handle.GetNumThreads();
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(numThreads)
@@ -481,7 +481,7 @@ RppStatus fog_f16_f16_host_tensor(Rpp16f *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -873,7 +873,7 @@ RppStatus fog_f32_f32_host_tensor(Rpp32f *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1265,7 +1265,7 @@ RppStatus fog_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 RppLayoutParams layoutParams,
                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/fog.cpp
+++ b/src/modules/tensor/cpu/kernel/fog.cpp
@@ -100,11 +100,11 @@ RppStatus fog_u8_u8_host_tensor(Rpp8u *srcPtr,
                                 RppLayoutParams layoutParams,
                                 rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -482,10 +482,9 @@ RppStatus fog_f16_f16_host_tensor(Rpp16f *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -874,10 +873,9 @@ RppStatus fog_f32_f32_host_tensor(Rpp32f *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1266,10 +1264,9 @@ RppStatus fog_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/fused_multiply_add_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/fused_multiply_add_scalar.cpp
@@ -42,9 +42,9 @@ RppStatus fused_multiply_add_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/fused_multiply_add_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/fused_multiply_add_scalar.cpp
@@ -45,10 +45,9 @@ RppStatus fused_multiply_add_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/gamma_correction.cpp
+++ b/src/modules/tensor/cpu/kernel/gamma_correction.cpp
@@ -34,7 +34,7 @@ RppStatus gamma_correction_u8_u8_host_tensor(Rpp8u *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -184,7 +184,7 @@ RppStatus gamma_correction_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -334,7 +334,7 @@ RppStatus gamma_correction_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -484,7 +484,7 @@ RppStatus gamma_correction_i8_i8_host_tensor(Rpp8s *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/gamma_correction.cpp
+++ b/src/modules/tensor/cpu/kernel/gamma_correction.cpp
@@ -35,10 +35,9 @@ RppStatus gamma_correction_u8_u8_host_tensor(Rpp8u *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -185,10 +184,9 @@ RppStatus gamma_correction_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -335,10 +333,9 @@ RppStatus gamma_correction_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -485,10 +482,9 @@ RppStatus gamma_correction_i8_i8_host_tensor(Rpp8s *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
@@ -80,8 +80,6 @@ RppStatus gaussian_filter_host_tensor(T *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
         return gaussian_filter_generic_host_tensor(srcPtr, srcDescPtr, dstPtr, dstDescPtr, stdDevTensor, kernelSize, roiTensorPtrSrc, roiType, layoutParams, handle);
 
@@ -92,7 +90,8 @@ RppStatus gaussian_filter_host_tensor(T *srcPtr,
 #endif
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1231,10 +1230,9 @@ RppStatus gaussian_filter_generic_host_tensor(T *srcPtr,
                                               rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
@@ -79,7 +79,7 @@ RppStatus gaussian_filter_host_tensor(T *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     if ((kernelSize != 3) && (kernelSize != 5) && (kernelSize != 7) && (kernelSize != 9))
@@ -1230,7 +1230,7 @@ RppStatus gaussian_filter_generic_host_tensor(T *srcPtr,
                                               RppLayoutParams layoutParams,
                                               rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/glitch.cpp
+++ b/src/modules/tensor/cpu/kernel/glitch.cpp
@@ -68,10 +68,9 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -244,10 +243,9 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -420,10 +418,9 @@ RppStatus glitch_f16_f16_host_tensor(Rpp16f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -533,10 +530,9 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/glitch.cpp
+++ b/src/modules/tensor/cpu/kernel/glitch.cpp
@@ -67,7 +67,7 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -243,7 +243,7 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -419,7 +419,7 @@ RppStatus glitch_f16_f16_host_tensor(Rpp16f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -532,7 +532,7 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/glitch.cpp
+++ b/src/modules/tensor/cpu/kernel/glitch.cpp
@@ -83,7 +83,6 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
         srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
         dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
 
-        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp8u *srcPtrChannel, *dstPtrChannel;
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;
@@ -258,7 +257,6 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
         srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
         dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
 
-        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp32f *srcPtrChannel, *dstPtrChannel;
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;
@@ -433,7 +431,6 @@ RppStatus glitch_f16_f16_host_tensor(Rpp16f *srcPtr,
         srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
         dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
 
-        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp16f *srcPtrChannel, *dstPtrChannel;
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;
@@ -545,7 +542,6 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
         srcPtrImage = srcPtr + batchCount * srcDescPtr->strides.nStride;
         dstPtrImage = dstPtr + batchCount * dstDescPtr->strides.nStride;
 
-        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp8s *srcPtrChannel, *dstPtrChannel;
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;

--- a/src/modules/tensor/cpu/kernel/grid_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/grid_dropout.cpp
@@ -39,7 +39,7 @@ RppStatus grid_dropout_host_tensor(T *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     T fillValue{};

--- a/src/modules/tensor/cpu/kernel/grid_dropout.cpp
+++ b/src/modules/tensor/cpu/kernel/grid_dropout.cpp
@@ -40,14 +40,13 @@ RppStatus grid_dropout_host_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     T fillValue{};
     if (std::is_same<T, Rpp8s>::value)
         fillValue = -128;
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/gridmask.cpp
+++ b/src/modules/tensor/cpu/kernel/gridmask.cpp
@@ -144,10 +144,9 @@ RppStatus gridmask_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -550,10 +549,9 @@ RppStatus gridmask_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -938,10 +936,9 @@ RppStatus gridmask_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1444,10 +1441,9 @@ RppStatus gridmask_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/gridmask.cpp
+++ b/src/modules/tensor/cpu/kernel/gridmask.cpp
@@ -143,7 +143,7 @@ RppStatus gridmask_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -549,7 +549,7 @@ RppStatus gridmask_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -937,7 +937,7 @@ RppStatus gridmask_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1443,7 +1443,7 @@ RppStatus gridmask_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/histogram_equalize.cpp
+++ b/src/modules/tensor/cpu/kernel/histogram_equalize.cpp
@@ -273,7 +273,7 @@ RppStatus histogram_equalize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h)};
+    RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
     Rpp32u numThreads = handle.GetNumThreads();
 
     // Pre-allocate YCbCr buffers for 3-channel images outside the parallel loop
@@ -301,7 +301,8 @@ RppStatus histogram_equalize_u8_u8_host_tensor(Rpp8u *srcPtr,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(static_cast<int>(numThreads));
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/hue.cpp
+++ b/src/modules/tensor/cpu/kernel/hue.cpp
@@ -87,7 +87,7 @@ RppStatus hue_u8_u8_host_tensor(Rpp8u *srcPtr,
                                 RppLayoutParams layoutParams,
                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -383,7 +383,7 @@ RppStatus hue_f32_f32_host_tensor(Rpp32f *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -667,7 +667,7 @@ RppStatus hue_f16_f16_host_tensor(Rpp16f *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -991,7 +991,7 @@ RppStatus hue_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 RppLayoutParams layoutParams,
                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/hue.cpp
+++ b/src/modules/tensor/cpu/kernel/hue.cpp
@@ -88,10 +88,9 @@ RppStatus hue_u8_u8_host_tensor(Rpp8u *srcPtr,
                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -384,10 +383,9 @@ RppStatus hue_f32_f32_host_tensor(Rpp32f *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -668,10 +666,9 @@ RppStatus hue_f16_f16_host_tensor(Rpp16f *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -992,10 +989,9 @@ RppStatus hue_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/jitter.cpp
+++ b/src/modules/tensor/cpu/kernel/jitter.cpp
@@ -415,8 +415,7 @@ RppStatus jitter_f32_f32_host_tensor(Rpp32f *srcPtr,
         // Jitter without fused output-layout toggle (NHWC -> NHWC)
         else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            Rpp32f *srcPtrRow, *dstPtrRow;
-            srcPtrRow = srcPtrChannel;
+            Rpp32f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
 
             for(int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
@@ -642,8 +641,7 @@ RppStatus jitter_f16_f16_host_tensor(Rpp16f *srcPtr,
         // Jitter without fused output-layout toggle (NHWC -> NHWC)
         else if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            Rpp16f *srcPtrRow, *dstPtrRow;
-            srcPtrRow = srcPtrChannel;
+            Rpp16f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
 
             for(int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)

--- a/src/modules/tensor/cpu/kernel/jitter.cpp
+++ b/src/modules/tensor/cpu/kernel/jitter.cpp
@@ -57,10 +57,9 @@ RppStatus jitter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -289,10 +288,9 @@ RppStatus jitter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -507,10 +505,9 @@ RppStatus jitter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -751,10 +748,9 @@ RppStatus jitter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/jitter.cpp
+++ b/src/modules/tensor/cpu/kernel/jitter.cpp
@@ -56,7 +56,7 @@ RppStatus jitter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -288,7 +288,7 @@ RppStatus jitter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -506,7 +506,7 @@ RppStatus jitter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -750,7 +750,7 @@ RppStatus jitter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
@@ -749,10 +749,9 @@ RppStatus jpeg_compression_distortion_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32s batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1137,10 +1136,9 @@ RppStatus jpeg_compression_distortion_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                           rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32s batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1560,10 +1558,9 @@ RppStatus jpeg_compression_distortion_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                           rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32s batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1983,8 +1980,6 @@ RppStatus jpeg_compression_distortion_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(1)
     for(Rpp32s batchCount = 0; batchCount < dstDescPtr->n; batchCount++)

--- a/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
@@ -748,7 +748,7 @@ RppStatus jpeg_compression_distortion_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                         RppLayoutParams layoutParams,
                                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1136,7 +1136,7 @@ RppStatus jpeg_compression_distortion_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                           RppLayoutParams layoutParams,
                                                           rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1559,7 +1559,7 @@ RppStatus jpeg_compression_distortion_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                           RppLayoutParams layoutParams,
                                                           rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1982,7 +1982,7 @@ RppStatus jpeg_compression_distortion_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                         RppLayoutParams layoutParams,
                                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/cpu/kernel/jpeg_compression_distortion.cpp
@@ -51,14 +51,11 @@ const __m256 pCoeffCrG = _mm256_set1_ps(-0.418688f);
 const __m256 pCoeffCrB = _mm256_set1_ps(-0.081312f);
 
 // Coefficients for YCbCr to RGB conversion
-const __m256 pCoeffRY = avx_p1;
 const __m256 pCoeffRCr = _mm256_set1_ps(1.402f);
 
-const __m256 pCoeffGY = avx_p1;
 const __m256 pCoeffGCb = _mm256_set1_ps(-0.344136f);
 const __m256 pCoeffGCr = _mm256_set1_ps(-0.714136f);
 
-const __m256 pCoeffBY = avx_p1;
 const __m256 pCoeffBCb = _mm256_set1_ps(1.772f);
 
 const __m256i pxMask = _mm256_setr_epi32(0, 1, 4, 5, 2, 3, 6, 7);
@@ -768,7 +765,6 @@ RppStatus jpeg_compression_distortion_u8_u8_host_tensor(Rpp8u *srcPtr,
 
         Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp32u alignedLength = (bufferLength / 16) * 16;
-        Rpp32u vectorIncrement = 48;
         Rpp32u vectorIncrementPerChannel = 16;
         Rpp32s qualityParam = qualityTensor[batchCount];
         Rpp32f *scratchMem = handle.GetInitHandle()->mem.mcpu.scratchBufferHost + (batchCount * (16 * 16 * 3));  // (16 * 16) is the block size, and 3 represents the number of channels
@@ -1155,7 +1151,6 @@ RppStatus jpeg_compression_distortion_f32_f32_host_tensor(Rpp32f *srcPtr,
 
         Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp32u alignedLength = (bufferLength / 16) * 16;
-        Rpp32u vectorIncrement = 48;
         Rpp32u vectorIncrementPerChannel = 16;
         Rpp32s qualityParam = qualityTensor[batchCount];
         Rpp32f *scratchMem = handle.GetInitHandle()->mem.mcpu.scratchBufferHost + (batchCount * (16 * 16 * 3));  // (16 * 16) is the block size, and 3 represents the number of channels
@@ -1577,7 +1572,6 @@ RppStatus jpeg_compression_distortion_f16_f16_host_tensor(Rpp16f *srcPtr,
 
         Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp32u alignedLength = (bufferLength / 16) * 16;
-        Rpp32u vectorIncrement = 48;
         Rpp32u vectorIncrementPerChannel = 16;
         Rpp32s qualityParam = qualityTensor[batchCount];
         Rpp32f *scratchMem = handle.GetInitHandle()->mem.mcpu.scratchBufferHost + (batchCount * (16 * 16 * 3));  // (16 * 16) is the block size, and 3 represents the number of channels
@@ -1998,7 +1992,6 @@ RppStatus jpeg_compression_distortion_i8_i8_host_tensor(Rpp8s *srcPtr,
 
         Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
         Rpp32u alignedLength = (bufferLength / 16) * 16;
-        Rpp32u vectorIncrement = 48;
         Rpp32u vectorIncrementPerChannel = 16;
         Rpp32s qualityParam = qualityTensor[batchCount];
         Rpp32f *scratchMem = handle.GetInitHandle()->mem.mcpu.scratchBufferHost + (batchCount * (16 * 16 * 3));  // (16 * 16) is the block size, and 3 represents the number of channels

--- a/src/modules/tensor/cpu/kernel/lens_correction.cpp
+++ b/src/modules/tensor/cpu/kernel/lens_correction.cpp
@@ -52,9 +52,9 @@ void compute_lens_correction_remap_tables_host_tensor(RpptDescPtr srcDescPtr,
                                                       RpptROIPtr roiTensorPtrSrc,
                                                       rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *rowRemapTableTemp, *colRemapTableTemp;

--- a/src/modules/tensor/cpu/kernel/lens_correction.cpp
+++ b/src/modules/tensor/cpu/kernel/lens_correction.cpp
@@ -101,10 +101,6 @@ void compute_lens_correction_remap_tables_host_tensor(RpptDescPtr srcDescPtr,
         pInvMat3 = _mm256_set1_ps(invMat[3]);
         pInvMat6 = _mm256_set1_ps(invMat[6]);
 
-        __m256 pXCameraIncrement, pYCameraIncrement, pZCameraIncrement;
-        pXCameraIncrement = _mm256_mul_ps(pInvMat0, avx_p8);
-        pYCameraIncrement = _mm256_mul_ps(pInvMat3, avx_p8);
-        pZCameraIncrement = _mm256_mul_ps(pInvMat6, avx_p8);
         for(int i = 0; i < height; i++)
         {
             Rpp32f *rowRemapTableRow = rowRemapTableTemp + i * tableDescPtr->strides.hStride;

--- a/src/modules/tensor/cpu/kernel/lens_correction.cpp
+++ b/src/modules/tensor/cpu/kernel/lens_correction.cpp
@@ -101,7 +101,6 @@ void compute_lens_correction_remap_tables_host_tensor(RpptDescPtr srcDescPtr,
         pInvMat3 = _mm256_set1_ps(invMat[3]);
         pInvMat6 = _mm256_set1_ps(invMat[6]);
 
-        __m256 pXCameraInit, pYCameraInit, pZCameraInit;
         __m256 pXCameraIncrement, pYCameraIncrement, pZCameraIncrement;
         pXCameraIncrement = _mm256_mul_ps(pInvMat0, avx_p8);
         pYCameraIncrement = _mm256_mul_ps(pInvMat3, avx_p8);

--- a/src/modules/tensor/cpu/kernel/log.cpp
+++ b/src/modules/tensor/cpu/kernel/log.cpp
@@ -57,12 +57,12 @@ RppStatus log_generic_host_tensor(Rpp8u *srcPtr,
                                   Rpp32u *roiTensor,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u nDim = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *roi = roiTensor + batchCount * nDim * 2;
@@ -183,12 +183,12 @@ RppStatus log_generic_host_tensor(Rpp8s *srcPtr,
                                   Rpp32u *roiTensor,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u nDim = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *roi = roiTensor + batchCount * nDim * 2;
@@ -309,12 +309,12 @@ RppStatus log_generic_host_tensor(Rpp32f *srcPtr,
                                   Rpp32u *roiTensor,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u nDim = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *roi = roiTensor + batchCount * nDim * 2;
@@ -435,12 +435,12 @@ RppStatus log_generic_host_tensor(Rpp16f *srcPtr,
                                   Rpp32u *roiTensor,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u nDim = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *roi = roiTensor + batchCount * nDim * 2;

--- a/src/modules/tensor/cpu/kernel/log1p.cpp
+++ b/src/modules/tensor/cpu/kernel/log1p.cpp
@@ -56,12 +56,12 @@ RppStatus log1p_i16_f32_host_tensor(Rpp16s *srcPtr,
                                     Rpp32u *roiTensor,
                                     rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u nDim = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *roi = roiTensor + batchCount * nDim * 2;

--- a/src/modules/tensor/cpu/kernel/lut.cpp
+++ b/src/modules/tensor/cpu/kernel/lut.cpp
@@ -33,7 +33,7 @@ RppStatus lut_u8_u8_host_tensor(Rpp8u *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -170,7 +170,7 @@ RppStatus lut_u8_f16_host_tensor(Rpp8u *srcPtr,
                                  RpptRoiType roiType,
                                  RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -315,7 +315,7 @@ RppStatus lut_u8_f32_host_tensor(Rpp8u *srcPtr,
                                  RpptRoiType roiType,
                                  RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)
@@ -460,7 +460,7 @@ RppStatus lut_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(dstDescPtr->n)

--- a/src/modules/tensor/cpu/kernel/magnitude.cpp
+++ b/src/modules/tensor/cpu/kernel/magnitude.cpp
@@ -35,10 +35,9 @@ RppStatus magnitude_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -282,10 +281,9 @@ RppStatus magnitude_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -514,10 +512,9 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -745,10 +742,9 @@ RppStatus magnitude_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/magnitude.cpp
+++ b/src/modules/tensor/cpu/kernel/magnitude.cpp
@@ -34,7 +34,7 @@ RppStatus magnitude_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -281,7 +281,7 @@ RppStatus magnitude_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -513,7 +513,7 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -744,7 +744,7 @@ RppStatus magnitude_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/median_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/median_filter.cpp
@@ -1331,7 +1331,7 @@ RppStatus median_filter_generic_host_tensor(T *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/median_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/median_filter.cpp
@@ -1332,10 +1332,9 @@ RppStatus median_filter_generic_host_tensor(T *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32s batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/mel_filter_bank.cpp
+++ b/src/modules/tensor/cpu/kernel/mel_filter_bank.cpp
@@ -48,7 +48,6 @@ RppStatus mel_filter_bank_host_tensor(Rpp32f *srcPtr,
             melScalePtr = new SlaneyMelScale();
             break;
     }
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u batchSize = srcDescPtr->n;
     Rpp32f *scratchMem = handle.GetInitHandle()->mem.mcpu.scratchBufferHost;
 
@@ -61,7 +60,8 @@ RppStatus mel_filter_bank_host_tensor(Rpp32f *srcPtr,
     Rpp64f melStep = (melHigh - melLow) / (numFilter + 1);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/multiply_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/multiply_scalar.cpp
@@ -42,9 +42,9 @@ RppStatus multiply_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/multiply_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/multiply_scalar.cpp
@@ -45,10 +45,9 @@ RppStatus multiply_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
@@ -199,10 +199,9 @@ RppStatus gaussian_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -532,10 +531,9 @@ RppStatus gaussian_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -854,10 +852,9 @@ RppStatus gaussian_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1231,10 +1228,9 @@ RppStatus gaussian_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1568,11 +1564,11 @@ RppStatus gaussian_noise_voxel_u8_u8_host_tensor(Rpp8u *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         RpptROI3D roi;
@@ -1818,11 +1814,11 @@ RppStatus gaussian_noise_voxel_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
@@ -53,7 +53,7 @@ inline void compute_gaussian_noise_16_host(__m256 *p, __m256i *pxXorwowStateX, _
 
 inline void compute_gaussian_noise_voxel_16_host(__m256 *p, __m256i *pxXorwowStateX, __m256i *pxXorwowStateCounter, __m256 *pGaussianNoiseParams)
 {
-    __m256 pRngVals[2], pSqrt[2];
+    __m256 pRngVals[2];
 
     rpp_host_rng_16_gaussian_f32_avx(pRngVals, pxXorwowStateX, pxXorwowStateCounter);               // rngVal = rpp_host_rng_1_gaussian_f32(xorwowStatePtr);
     pRngVals[0] = _mm256_fmadd_ps(pRngVals[0], pGaussianNoiseParams[1], pGaussianNoiseParams[0]);   // rngVal = rngVal * stdDev + mean;
@@ -77,7 +77,7 @@ inline void compute_gaussian_noise_8_host(__m128 *p, __m128i *pxXorwowStateX, __
 
 inline void compute_gaussian_noise_voxel_8_host(__m128 *p, __m128i *pxXorwowStateX, __m128i *pxXorwowStateCounter, __m128 *pGaussianNoiseParams)
 {
-    __m128 pRngVals[2], pSqrt[2];
+    __m128 pRngVals[2];
 
     rpp_host_rng_8_gaussian_f32_sse(pRngVals, pxXorwowStateX, pxXorwowStateCounter);            // rngVal = rpp_host_rng_1_gaussian_f32(xorwowStatePtr);
     pRngVals[0] = _mm_fmadd_ps(pRngVals[0], pGaussianNoiseParams[1], pGaussianNoiseParams[0]);  // rngVal = rngVal * stdDev + mean;
@@ -162,7 +162,7 @@ inline void compute_gaussian_noise_voxel_12_host(__m128 *p, __m128i *pxXorwowSta
 {
     compute_gaussian_noise_8_host(p, pxXorwowStateX, pxXorwowStateCounter, pGaussianNoiseParams);
 
-    __m128 pRngVals[2], pSqrt;
+    __m128 pRngVals[2];
     rpp_host_rng_8_gaussian_f32_sse(pRngVals, pxXorwowStateX, pxXorwowStateCounter);            // rngVal = rpp_host_rng_1_gaussian_f32(xorwowStatePtr);
     pRngVals[0] = _mm_fmadd_ps(pRngVals[0], pGaussianNoiseParams[1], pGaussianNoiseParams[0]);  // rngVal = rngVal * stdDev + mean;
     p[2] = _mm_add_ps(p[2], pRngVals[0]);                                                       // return pixVal + rngVal;
@@ -180,7 +180,7 @@ inline Rpp32f compute_gaussian_noise_1_host(Rpp32f pixVal, RpptXorwowStateBoxMul
 
 inline Rpp32f compute_gaussian_noise_voxel_1_host(Rpp32f pixVal, RpptXorwowStateBoxMuller *xorwowStatePtr, Rpp32f mean, Rpp32f stdDev)
 {
-    Rpp32f rngVal, pixSqrt;
+    Rpp32f rngVal;
     rngVal = rpp_host_rng_1_gaussian_f32(xorwowStatePtr);
     rngVal = rngVal * stdDev + mean;
     return pixVal + rngVal;

--- a/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_gaussian.cpp
@@ -198,7 +198,7 @@ RppStatus gaussian_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -531,7 +531,7 @@ RppStatus gaussian_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -853,7 +853,7 @@ RppStatus gaussian_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1230,7 +1230,7 @@ RppStatus gaussian_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1565,9 +1565,9 @@ RppStatus gaussian_noise_voxel_u8_u8_host_tensor(Rpp8u *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -1815,9 +1815,9 @@ RppStatus gaussian_noise_voxel_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 

--- a/src/modules/tensor/cpu/kernel/noise_salt_and_pepper.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_salt_and_pepper.cpp
@@ -144,10 +144,9 @@ RppStatus salt_and_pepper_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -517,10 +516,9 @@ RppStatus salt_and_pepper_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -897,10 +895,9 @@ RppStatus salt_and_pepper_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1332,10 +1329,9 @@ RppStatus salt_and_pepper_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/noise_salt_and_pepper.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_salt_and_pepper.cpp
@@ -143,7 +143,7 @@ RppStatus salt_and_pepper_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                   RppLayoutParams layoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -516,7 +516,7 @@ RppStatus salt_and_pepper_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -896,7 +896,7 @@ RppStatus salt_and_pepper_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1331,7 +1331,7 @@ RppStatus salt_and_pepper_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                   RppLayoutParams layoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/noise_shot.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_shot.cpp
@@ -158,10 +158,9 @@ RppStatus shot_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -539,10 +538,9 @@ RppStatus shot_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -929,10 +927,9 @@ RppStatus shot_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1374,10 +1371,9 @@ RppStatus shot_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/noise_shot.cpp
+++ b/src/modules/tensor/cpu/kernel/noise_shot.cpp
@@ -157,7 +157,7 @@ RppStatus shot_noise_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -538,7 +538,7 @@ RppStatus shot_noise_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -928,7 +928,7 @@ RppStatus shot_noise_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1373,7 +1373,7 @@ RppStatus shot_noise_i8_i8_host_tensor(Rpp8s *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/non_linear_blend.cpp
+++ b/src/modules/tensor/cpu/kernel/non_linear_blend.cpp
@@ -84,7 +84,7 @@ RppStatus non_linear_blend_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle &handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -452,7 +452,7 @@ RppStatus non_linear_blend_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle &handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -820,7 +820,7 @@ RppStatus non_linear_blend_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle &handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1188,7 +1188,7 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle &handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/non_linear_blend.cpp
+++ b/src/modules/tensor/cpu/kernel/non_linear_blend.cpp
@@ -85,10 +85,9 @@ RppStatus non_linear_blend_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                              rpp::Handle &handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -453,10 +452,9 @@ RppStatus non_linear_blend_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                                rpp::Handle &handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -821,10 +819,9 @@ RppStatus non_linear_blend_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                              rpp::Handle &handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1189,10 +1186,9 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                                rpp::Handle &handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/non_silent_region_detection.cpp
+++ b/src/modules/tensor/cpu/kernel/non_silent_region_detection.cpp
@@ -101,11 +101,11 @@ RppStatus non_silent_region_detection_host_tensor(Rpp32f *srcPtr,
                                                   Rpp32s resetInterval,
                                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     const Rpp32f cutOff = std::pow(10.0f, cutOffDB * 0.1f);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/normalize.cpp
@@ -594,13 +594,11 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
         {
             Rpp32u paramStride[3];
             Rpp32u srcReductionDims[3], srcStride[3];
-            Rpp32u reductionDims;
             bool isConsecutive = true;
             switch(axisMask)
             {
                 case 1: // Normalize axes 0
                 {
-                    reductionDims = length[1] * length[2];
                     paramStride[0] = 0;
                     paramStride[1] = paramStride[2] = 1;
                     srcReductionDims[0] = length[1];
@@ -613,7 +611,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 2: // Normalize axes 1
                 {
-                    reductionDims = length[0] * length[2];
                     paramStride[1] = 0;
                     paramStride[0] = paramStride[2] = 1;
                     srcReductionDims[0] = length[0];
@@ -626,7 +623,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 3: // Normalize axes 0, 1
                 {
-                    reductionDims = length[2];
                     paramStride[0] = paramStride[1] = 0;
                     paramStride[2] = 1;
                     srcReductionDims[0] = 1;
@@ -639,7 +635,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 4: // Normalize across 2
                 {
-                    reductionDims = length[0] * length[1];
                     paramStride[2] = 0;
                     paramStride[0] = paramStride[1] = 1;
                     srcReductionDims[0] = length[0];
@@ -652,7 +647,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 5: // Normalize across 0, 2
                 {
-                    reductionDims = length[1];
                     paramStride[0] = paramStride[2] = 0;
                     paramStride[1] = 1;
                     srcReductionDims[0] = length[1];
@@ -666,7 +660,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 6: // Normalize across 1, 2
                 {
-                    reductionDims = length[0];
                     paramStride[1] = paramStride[2] = 0;
                     paramStride[0] = 1;
                     srcReductionDims[0] = 1;
@@ -679,7 +672,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                 }
                 case 7: // Normalize across 0, 1, 2
                 {
-                    reductionDims = 1;
                     paramStride[0] = paramStride[1] = paramStride[2] = 0;
                     srcReductionDims[0] = 1;
                     srcReductionDims[1] = 1;

--- a/src/modules/tensor/cpu/kernel/normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/normalize.cpp
@@ -512,7 +512,6 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = srcGenericDescPtr->numDims - 1;
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -534,7 +533,8 @@ RppStatus normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
 	{
         Rpp32u *roi = roiTensor + batchCount * tensorDims * 2;
@@ -772,7 +772,6 @@ RppStatus normalize_generic_host_tensor(T1 *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = srcGenericDescPtr->numDims - 1; // Omitting batchSize here to get tensor dimension.
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
@@ -792,7 +791,8 @@ RppStatus normalize_generic_host_tensor(T1 *srcPtr,
     }
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
 	{
         int size = 1;

--- a/src/modules/tensor/cpu/kernel/phase.cpp
+++ b/src/modules/tensor/cpu/kernel/phase.cpp
@@ -36,10 +36,9 @@ RppStatus phase_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -272,10 +271,9 @@ RppStatus phase_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -507,10 +505,9 @@ RppStatus phase_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -742,10 +739,9 @@ RppStatus phase_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/phase.cpp
+++ b/src/modules/tensor/cpu/kernel/phase.cpp
@@ -35,7 +35,7 @@ RppStatus phase_u8_u8_host_tensor(Rpp8u *srcPtr1,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -271,7 +271,7 @@ RppStatus phase_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -506,7 +506,7 @@ RppStatus phase_f16_f16_host_tensor(Rpp16f *srcPtr1,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -741,7 +741,7 @@ RppStatus phase_i8_i8_host_tensor(Rpp8s *srcPtr1,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/posterize.cpp
+++ b/src/modules/tensor/cpu/kernel/posterize.cpp
@@ -80,10 +80,9 @@ RppStatus posterize_char_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -322,10 +321,9 @@ RppStatus posterize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle) {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -523,10 +521,9 @@ RppStatus posterize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle) {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/posterize.cpp
+++ b/src/modules/tensor/cpu/kernel/posterize.cpp
@@ -79,7 +79,7 @@ RppStatus posterize_char_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -321,7 +321,7 @@ RppStatus posterize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         RpptRoiType roiType,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle) {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -522,7 +522,7 @@ RppStatus posterize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         RpptRoiType roiType,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle) {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/pre_emphasis_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/pre_emphasis_filter.cpp
@@ -33,10 +33,9 @@ RppStatus pre_emphasis_filter_host_tensor(Rpp32f *srcPtr,
                                           Rpp32u borderType,
                                           rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/rain.cpp
+++ b/src/modules/tensor/cpu/kernel/rain.cpp
@@ -105,7 +105,7 @@ RppStatus rain_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     Rpp8u *rainLayer = reinterpret_cast<Rpp8u *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);
@@ -389,7 +389,7 @@ RppStatus rain_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
     {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     Rpp32f *rainLayer = handle.GetInitHandle()->mem.mcpu.scratchBufferHost;
@@ -673,7 +673,7 @@ RppStatus rain_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     Rpp16f *rainLayer = reinterpret_cast<Rpp16f *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);
@@ -957,7 +957,7 @@ RppStatus rain_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     Rpp8s *rainLayer = reinterpret_cast<Rpp8s *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);

--- a/src/modules/tensor/cpu/kernel/rain.cpp
+++ b/src/modules/tensor/cpu/kernel/rain.cpp
@@ -106,14 +106,13 @@ RppStatus rain_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     Rpp8u *rainLayer = reinterpret_cast<Rpp8u *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);
     std::memset(rainLayer, 0, srcDescPtr->w * srcDescPtr->h * sizeof(Rpp8u));
     create_rain_layer(rainLayer, rainPercentage, srcDescPtr, slantAngle, rainHeight, rainWidth);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -390,14 +389,13 @@ RppStatus rain_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    rpp::Handle& handle)
     {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     Rpp32f *rainLayer = handle.GetInitHandle()->mem.mcpu.scratchBufferHost;
     std::memset(rainLayer, 0, srcDescPtr->w * srcDescPtr->h * sizeof(Rpp32f));
     create_rain_layer(rainLayer, rainPercentage, srcDescPtr, slantAngle, rainHeight, rainWidth);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -674,14 +672,13 @@ RppStatus rain_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     Rpp16f *rainLayer = reinterpret_cast<Rpp16f *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);
     std::memset(rainLayer, 0, srcDescPtr->w * srcDescPtr->h * sizeof(Rpp16f));
     create_rain_layer(rainLayer, rainPercentage, srcDescPtr, slantAngle, rainHeight, rainWidth);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -958,14 +955,13 @@ RppStatus rain_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     Rpp8s *rainLayer = reinterpret_cast<Rpp8s *>(handle.GetInitHandle()->mem.mcpu.scratchBufferHost);
     std::memset(rainLayer, 0x81, srcDescPtr->w * srcDescPtr->h * sizeof(Rpp8s));
     create_rain_layer(rainLayer, rainPercentage, srcDescPtr, slantAngle, rainHeight, rainWidth);
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/random_erase.cpp
+++ b/src/modules/tensor/cpu/kernel/random_erase.cpp
@@ -36,7 +36,7 @@ RppStatus random_erase_host_tensor(T *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/random_erase.cpp
+++ b/src/modules/tensor/cpu/kernel/random_erase.cpp
@@ -37,10 +37,9 @@ RppStatus random_erase_host_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/remap.cpp
+++ b/src/modules/tensor/cpu/kernel/remap.cpp
@@ -57,7 +57,7 @@ RppStatus remap_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
@@ -287,7 +287,7 @@ RppStatus remap_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
@@ -510,7 +510,7 @@ RppStatus remap_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
@@ -740,7 +740,7 @@ RppStatus remap_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
@@ -854,7 +854,7 @@ RppStatus remap_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            RppLayoutParams layoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 #if __AVX2__
     __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
@@ -1136,7 +1136,7 @@ RppStatus remap_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
 #if __AVX2__
@@ -1419,7 +1419,7 @@ RppStatus remap_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            RppLayoutParams ,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
 #if __AVX2__
@@ -1707,7 +1707,7 @@ RppStatus remap_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              RppLayoutParams layoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
 #if __AVX2__

--- a/src/modules/tensor/cpu/kernel/remap.cpp
+++ b/src/modules/tensor/cpu/kernel/remap.cpp
@@ -738,8 +738,6 @@ RppStatus remap_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
-    __m128 pSrcStride = _mm_set1_ps(srcDescPtr->strides.hStride);
 
 omp_set_dynamic(0);
 omp_set_num_threads(handle.GetNumThreads());
@@ -852,7 +850,6 @@ RppStatus remap_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 #if __AVX2__
-    __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
     __m256i pxSrcStridesCHW[3];
     pxSrcStridesCHW[0] = _mm256_set1_epi32(srcDescPtr->strides.cStride);
@@ -1134,7 +1131,6 @@ RppStatus remap_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 #if __AVX2__
-    __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
     __m256i pxSrcStridesCHW[3];
     pxSrcStridesCHW[0] = _mm256_set1_epi32(srcDescPtr->strides.cStride);
@@ -1416,7 +1412,6 @@ RppStatus remap_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 #if __AVX2__
-    __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
     __m256i pxSrcStridesCHW[3];
     pxSrcStridesCHW[0] = _mm256_set1_epi32(srcDescPtr->strides.cStride);
@@ -1703,7 +1698,6 @@ RppStatus remap_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 #if __AVX2__
-    __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
     __m256i pxSrcStridesCHW[3];
     pxSrcStridesCHW[0] = _mm256_set1_epi32(srcDescPtr->strides.cStride);

--- a/src/modules/tensor/cpu/kernel/remap.cpp
+++ b/src/modules/tensor/cpu/kernel/remap.cpp
@@ -58,13 +58,12 @@ RppStatus remap_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
     __m128 pSrcStride = _mm_set1_ps(srcDescPtr->strides.hStride);
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -288,13 +287,12 @@ RppStatus remap_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
     __m128 pSrcStride = _mm_set1_ps(srcDescPtr->strides.hStride);
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -511,13 +509,12 @@ RppStatus remap_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
     __m128 pSrcStride = _mm_set1_ps(srcDescPtr->strides.hStride);
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -741,13 +738,12 @@ RppStatus remap_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     __m128 pSrcChannel = _mm_set1_ps(srcDescPtr->c);
     __m128 pSrcStride = _mm_set1_ps(srcDescPtr->strides.hStride);
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -855,7 +851,6 @@ RppStatus remap_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
 #if __AVX2__
     __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
@@ -866,7 +861,8 @@ RppStatus remap_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
 #endif
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1137,8 +1133,6 @@ RppStatus remap_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
 #if __AVX2__
     __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
@@ -1149,7 +1143,8 @@ RppStatus remap_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
 #endif
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1420,8 +1415,6 @@ RppStatus remap_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
 #if __AVX2__
     __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
@@ -1432,7 +1425,8 @@ RppStatus remap_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
 #endif
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1708,8 +1702,6 @@ RppStatus remap_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
 #if __AVX2__
     __m256 pSrcChannel = _mm256_set1_ps(srcDescPtr->c);
     __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
@@ -1720,7 +1712,8 @@ RppStatus remap_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
 #endif
 
 omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;

--- a/src/modules/tensor/cpu/kernel/resample.cpp
+++ b/src/modules/tensor/cpu/kernel/resample.cpp
@@ -34,10 +34,9 @@ RppStatus resample_host_tensor(Rpp32f *srcPtr,
                                RpptResamplingWindow &window,
                                rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/resample.cpp
+++ b/src/modules/tensor/cpu/kernel/resample.cpp
@@ -54,7 +54,6 @@ RppStatus resample_host_tensor(Rpp32f *srcPtr,
         else
         {
             Rpp32s outEnd = std::ceil(srcLength * outRate / inRate);
-            Rpp32s inPos = 0;
             Rpp32s block = 1 << 8;
             Rpp64f scale = static_cast<Rpp64f>(inRate) / outRate;
             Rpp32f fscale = scale;

--- a/src/modules/tensor/cpu/kernel/resize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize.cpp
@@ -195,7 +195,6 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
     Rpp32s filterKernelRadiusWStrided = (Rpp32s)(filter.radius) * inputDescPtr->strides.wStride;
 
     Rpp32s inputWidthLimit = (inputImgSize.width - 1) * inputDescPtr->strides.wStride;
-    __m128i pxInputWidthLimit = _mm_set1_epi32(inputWidthLimit);
 
     // For PLN3 inputs
     if(inputDescPtr->c == 3 && inputDescPtr->layout == RpptLayout::NCHW)
@@ -1294,8 +1293,6 @@ RppStatus resize_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * srcLayoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;
 
-        Rpp32u alignedLength = dstImgSize[batchCount].width & ~3;
-        Rpp32s srcLocationColumnArray[4] = {0};
         Rpp32s srcLocationRow, srcLocationColumn;
 
         // Resize with 3 channel inputs and outputs

--- a/src/modules/tensor/cpu/kernel/resize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize.cpp
@@ -619,10 +619,9 @@ RppStatus resize_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -840,10 +839,9 @@ RppStatus resize_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1053,10 +1051,9 @@ RppStatus resize_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1274,10 +1271,9 @@ RppStatus resize_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1384,10 +1380,9 @@ RppStatus resize_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                             rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1626,10 +1621,9 @@ RppStatus resize_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                               rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1870,10 +1864,9 @@ RppStatus resize_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                               rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2114,10 +2107,9 @@ RppStatus resize_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                             rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -2360,10 +2352,9 @@ RppStatus resize_separable_host_tensor(T *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/resize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize.cpp
@@ -618,7 +618,7 @@ RppStatus resize_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                       RppLayoutParams srcLayoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -839,7 +839,7 @@ RppStatus resize_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         RppLayoutParams srcLayoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1052,7 +1052,7 @@ RppStatus resize_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       RppLayoutParams srcLayoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1273,7 +1273,7 @@ RppStatus resize_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         RppLayoutParams srcLayoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1383,7 +1383,7 @@ RppStatus resize_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                             RppLayoutParams srcLayoutParams,
                                             rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1625,7 +1625,7 @@ RppStatus resize_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                               RppLayoutParams srcLayoutParams,
                                               rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1869,7 +1869,7 @@ RppStatus resize_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                               RppLayoutParams srcLayoutParams,
                                               rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -2113,7 +2113,7 @@ RppStatus resize_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                             RppLayoutParams srcLayoutParams,
                                             rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -2359,7 +2359,7 @@ RppStatus resize_separable_host_tensor(T *srcPtr,
                                        RpptInterpolationType interpolationType,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/resize_crop_mirror.cpp
+++ b/src/modules/tensor/cpu/kernel/resize_crop_mirror.cpp
@@ -45,7 +45,7 @@ RppStatus resize_crop_mirror_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -301,7 +301,7 @@ RppStatus resize_crop_mirror_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                  RppLayoutParams layoutParams,
                                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -559,7 +559,7 @@ RppStatus resize_crop_mirror_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                  RppLayoutParams layoutParams,
                                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -820,7 +820,7 @@ RppStatus resize_crop_mirror_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                RppLayoutParams layoutParams,
                                                rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/resize_crop_mirror.cpp
+++ b/src/modules/tensor/cpu/kernel/resize_crop_mirror.cpp
@@ -46,10 +46,9 @@ RppStatus resize_crop_mirror_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -302,10 +301,9 @@ RppStatus resize_crop_mirror_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -560,10 +558,9 @@ RppStatus resize_crop_mirror_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -821,10 +818,9 @@ RppStatus resize_crop_mirror_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/resize_mirror_normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize_mirror_normalize.cpp
@@ -52,10 +52,9 @@ RppStatus resize_mirror_normalize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -334,10 +333,9 @@ RppStatus resize_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -628,10 +626,9 @@ RppStatus resize_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -914,10 +911,9 @@ RppStatus resize_mirror_normalize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1201,10 +1197,9 @@ RppStatus resize_mirror_normalize_u8_f32_host_tensor(Rpp8u *srcPtr,
                                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1485,10 +1480,9 @@ RppStatus resize_mirror_normalize_u8_f16_host_tensor(Rpp8u *srcPtr,
                                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/resize_mirror_normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize_mirror_normalize.cpp
@@ -51,7 +51,7 @@ RppStatus resize_mirror_normalize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -333,7 +333,7 @@ RppStatus resize_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                       RppLayoutParams layoutParams,
                                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -627,7 +627,7 @@ RppStatus resize_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                       RppLayoutParams layoutParams,
                                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -913,7 +913,7 @@ RppStatus resize_mirror_normalize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                     RppLayoutParams layoutParams,
                                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1200,7 +1200,7 @@ RppStatus resize_mirror_normalize_u8_f32_host_tensor(Rpp8u *srcPtr,
                                                      RppLayoutParams layoutParams,
                                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1484,7 +1484,7 @@ RppStatus resize_mirror_normalize_u8_f16_host_tensor(Rpp8u *srcPtr,
                                                      RppLayoutParams layoutParams,
                                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/ricap.cpp
+++ b/src/modules/tensor/cpu/kernel/ricap.cpp
@@ -47,10 +47,9 @@ RppStatus ricap_u8_u8_host_tensor(Rpp8u *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi[4];
@@ -405,10 +404,9 @@ RppStatus ricap_f32_f32_host_tensor(Rpp32f *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi[4];
@@ -766,10 +764,9 @@ RppStatus ricap_f16_f16_host_tensor(Rpp16f *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi[4];
@@ -1273,10 +1270,9 @@ RppStatus ricap_i8_i8_host_tensor(Rpp8s *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi[4];

--- a/src/modules/tensor/cpu/kernel/ricap.cpp
+++ b/src/modules/tensor/cpu/kernel/ricap.cpp
@@ -46,7 +46,7 @@ RppStatus ricap_u8_u8_host_tensor(Rpp8u *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -404,7 +404,7 @@ RppStatus ricap_f32_f32_host_tensor(Rpp32f *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -765,7 +765,7 @@ RppStatus ricap_f16_f16_host_tensor(Rpp16f *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1272,7 +1272,7 @@ RppStatus ricap_i8_i8_host_tensor(Rpp8s *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/saturation.cpp
+++ b/src/modules/tensor/cpu/kernel/saturation.cpp
@@ -93,7 +93,7 @@ RppStatus saturation_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -386,7 +386,7 @@ RppStatus saturation_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -667,7 +667,7 @@ RppStatus saturation_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          RppLayoutParams layoutParams,
                                          rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1003,7 +1003,7 @@ RppStatus saturation_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 RppLayoutParams layoutParams,
                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/saturation.cpp
+++ b/src/modules/tensor/cpu/kernel/saturation.cpp
@@ -94,10 +94,9 @@ RppStatus saturation_u8_u8_host_tensor(Rpp8u *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -387,10 +386,9 @@ RppStatus saturation_f32_f32_host_tensor(Rpp32f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -668,10 +666,9 @@ RppStatus saturation_f16_f16_host_tensor(Rpp16f *srcPtr,
                                          rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1004,10 +1001,9 @@ RppStatus saturation_i8_i8_host_tensor(Rpp8s *srcPtr,
                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/slice.cpp
+++ b/src/modules/tensor/cpu/kernel/slice.cpp
@@ -37,11 +37,11 @@ RppStatus slice_host_tensor(T *srcPtr,
                             RppLayoutParams layoutParams,
                             rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u numDims = srcGenericDescPtr->numDims - 1; // exclude batchsize from input dims
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         T *srcPtrTemp, *dstPtrTemp;

--- a/src/modules/tensor/cpu/kernel/snow.cpp
+++ b/src/modules/tensor/cpu/kernel/snow.cpp
@@ -150,7 +150,7 @@ inline void compute_snow_host(RpptFloatRGB *pixel, Rpp32f brightnessCoefficient,
 
 inline void compute_snow_24_host(__m256 &pVecR, __m256 &pVecG, __m256 &pVecB, __m256 *pSnowParams)
 {
-    __m256 pA, pH, pS, pL, pCmax, pCmin, pDelta, pAdd;
+    __m256 pH, pS, pL, pCmax, pCmin, pDelta, pAdd;
     __m256 pMask[4];
     __m256 pHueCoefficient[3];
 

--- a/src/modules/tensor/cpu/kernel/snow.cpp
+++ b/src/modules/tensor/cpu/kernel/snow.cpp
@@ -277,7 +277,7 @@ RppStatus snow_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -601,7 +601,7 @@ RppStatus snow_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -901,7 +901,7 @@ RppStatus snow_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1200,7 +1200,7 @@ RppStatus snow_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  RppLayoutParams layoutParams,
                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/snow.cpp
+++ b/src/modules/tensor/cpu/kernel/snow.cpp
@@ -278,10 +278,9 @@ RppStatus snow_u8_u8_host_tensor(Rpp8u *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -602,10 +601,9 @@ RppStatus snow_f32_f32_host_tensor(Rpp32f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -902,10 +900,9 @@ RppStatus snow_f16_f16_host_tensor(Rpp16f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1201,10 +1198,9 @@ RppStatus snow_i8_i8_host_tensor(Rpp8s *srcPtr,
                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(Rpp32u batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/sobel_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/sobel_filter.cpp
@@ -158,14 +158,13 @@ RppStatus sobel_filter_host_tensor(T *srcPtr,
         return RPP_ERROR_INVALID_SRC_CHANNELS;
 
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
 #if __AVX2__
     __m256i pxMaskPln[7] = {avx_pxMaskRotate0To1, avx_pxMaskRotate0To2, avx_pxMaskRotate0To3, avx_pxMaskRotate0To4, avx_pxMaskRotate0To5, avx_pxMaskRotate0To6, avx_pxMaskRotate0To7};
     __m256i pxMaskPkd[7] = {avx_pxMaskRotate0To3, avx_pxMaskRotate0To6, avx_pxMaskRotate0To1, avx_pxMaskRotate0To4, avx_pxMaskRotate0To7, avx_pxMaskRotate0To2, avx_pxMaskRotate0To5};
 #endif
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/sobel_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/sobel_filter.cpp
@@ -157,7 +157,7 @@ RppStatus sobel_filter_host_tensor(T *srcPtr,
     if (srcDescPtr->c != 1)
         return RPP_ERROR_INVALID_SRC_CHANNELS;
 
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
 #if __AVX2__

--- a/src/modules/tensor/cpu/kernel/sobel_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/sobel_filter.cpp
@@ -160,7 +160,6 @@ RppStatus sobel_filter_host_tensor(T *srcPtr,
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 #if __AVX2__
     __m256i pxMaskPln[7] = {avx_pxMaskRotate0To1, avx_pxMaskRotate0To2, avx_pxMaskRotate0To3, avx_pxMaskRotate0To4, avx_pxMaskRotate0To5, avx_pxMaskRotate0To6, avx_pxMaskRotate0To7};
-    __m256i pxMaskPkd[7] = {avx_pxMaskRotate0To3, avx_pxMaskRotate0To6, avx_pxMaskRotate0To1, avx_pxMaskRotate0To4, avx_pxMaskRotate0To7, avx_pxMaskRotate0To2, avx_pxMaskRotate0To5};
 #endif
     omp_set_dynamic(0);
     omp_set_num_threads(handle.GetNumThreads());

--- a/src/modules/tensor/cpu/kernel/solarize.cpp
+++ b/src/modules/tensor/cpu/kernel/solarize.cpp
@@ -46,7 +46,7 @@ RppStatus solarize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -219,7 +219,7 @@ RppStatus solarize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -396,7 +396,7 @@ RppStatus solarize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -573,7 +573,7 @@ RppStatus solarize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/solarize.cpp
+++ b/src/modules/tensor/cpu/kernel/solarize.cpp
@@ -47,10 +47,9 @@ RppStatus solarize_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -220,10 +219,9 @@ RppStatus solarize_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -397,10 +395,9 @@ RppStatus solarize_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -574,10 +571,9 @@ RppStatus solarize_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/spatter.cpp
+++ b/src/modules/tensor/cpu/kernel/spatter.cpp
@@ -102,10 +102,9 @@ RppStatus spatter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -456,10 +455,9 @@ RppStatus spatter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -818,10 +816,9 @@ RppStatus spatter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1219,10 +1216,9 @@ RppStatus spatter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/spatter.cpp
+++ b/src/modules/tensor/cpu/kernel/spatter.cpp
@@ -101,7 +101,7 @@ RppStatus spatter_u8_u8_host_tensor(Rpp8u *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -455,7 +455,7 @@ RppStatus spatter_f32_f32_host_tensor(Rpp32f *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -817,7 +817,7 @@ RppStatus spatter_f16_f16_host_tensor(Rpp16f *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1218,7 +1218,7 @@ RppStatus spatter_i8_i8_host_tensor(Rpp8s *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/spectrogram.cpp
+++ b/src/modules/tensor/cpu/kernel/spectrogram.cpp
@@ -87,10 +87,7 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
     if (centerWindows) windowCenterOffset = windowLength / 2;
     if (nfft == 0) nfft = windowLength;
     const Rpp32s numBins = nfft / 2 + 1;
-    const Rpp32f mulFactor = (2.0 * M_PI) / nfft;
     const Rpp32u hStride = dstDescPtr->strides.hStride;
-    const Rpp32s alignedNfftLength = nfft & ~7;
-    const Rpp32s alignedNbinsLength = numBins & ~7;
     const Rpp32s alignedWindowLength = windowLength & ~7;
     const Rpp32s maxNumWindows = (vertical) ? dstDescPtr->w : dstDescPtr->h;
     const Rpp32u windowOutputStride = maxNumWindows * nfft;

--- a/src/modules/tensor/cpu/kernel/spectrogram.cpp
+++ b/src/modules/tensor/cpu/kernel/spectrogram.cpp
@@ -109,11 +109,10 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
         hann_window(windowFn, windowLength);
     else
         memcpy(windowFn, windowFunction, windowLength * sizeof(Rpp32f));
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Get windows output
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (Rpp32s batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrTemp = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/subtract_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/subtract_scalar.cpp
@@ -42,9 +42,9 @@ RppStatus subtract_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
 {
     RpptROI3D roiDefault;
     if(srcGenericDescPtr->layout==RpptLayout::NCDHW)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
-        roiDefault = {0, 0, 0, (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]};
+        roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/subtract_scalar.cpp
+++ b/src/modules/tensor/cpu/kernel/subtract_scalar.cpp
@@ -45,10 +45,9 @@ RppStatus subtract_scalar_f32_f32_host_tensor(Rpp32f *srcPtr,
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[4], (Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2]);
     else if(srcGenericDescPtr->layout==RpptLayout::NDHWC)
         roiDefault = rpp_make_roi3d_xyzwhd_full((Rpp32s)srcGenericDescPtr->dims[3], (Rpp32s)srcGenericDescPtr->dims[2], (Rpp32s)srcGenericDescPtr->dims[1]);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstGenericDescPtr->dims[0]; batchCount++)
     {
         RpptROI3D roi;

--- a/src/modules/tensor/cpu/kernel/tensor_bitwise_binary_operations.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_bitwise_binary_operations.cpp
@@ -77,7 +77,6 @@ RppStatus tensor_binary_bitwise_op_host_tensor(T *srcPtr1,
                                                Rpp32u *srcPtr2roiTensor,
                                                rpp::Handle& handle) {
 
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u src1NDim = srcPtr1GenericDescPtr->numDims - 1;  // Omitting batchSize here to get tensor dimension
     Rpp32u src2NDim = srcPtr2GenericDescPtr->numDims - 1;  // Omitting batchSize here to get tensor dimension
     Rpp32u dstDim = src1NDim > src2NDim ? src1NDim : src2NDim; // Destination dimension set to maximum of the input dimensions
@@ -95,7 +94,8 @@ RppStatus tensor_binary_bitwise_op_host_tensor(T *srcPtr1,
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32u *src1roi = srcPtr1roiTensor + batchCount * src1NDim * 2;

--- a/src/modules/tensor/cpu/kernel/tensor_max.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_max.cpp
@@ -167,7 +167,7 @@ RppStatus tensor_max_u8_u8_host(Rpp8u *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -368,7 +368,7 @@ RppStatus tensor_max_f32_f32_host(Rpp32f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -568,7 +568,7 @@ RppStatus tensor_max_f16_f16_host(Rpp16f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -769,7 +769,7 @@ RppStatus tensor_max_i8_i8_host(Rpp8s *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)

--- a/src/modules/tensor/cpu/kernel/tensor_max.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_max.cpp
@@ -241,7 +241,7 @@ RppStatus tensor_max_u8_u8_host(Rpp8u *srcPtr,
 
             for(int c = 0; c < layoutParams.channelParam; c++)
             {
-                Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+                Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
                 srcPtrRowR = srcPtrChannel;
                 srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
                 srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
@@ -843,7 +843,7 @@ RppStatus tensor_max_i8_i8_host(Rpp8s *srcPtr,
 
             for(int c = 0; c < layoutParams.channelParam; c++)
             {
-                Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+                Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
                 srcPtrRowR = srcPtrChannel;
                 srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
                 srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;

--- a/src/modules/tensor/cpu/kernel/tensor_mean.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_mean.cpp
@@ -103,7 +103,7 @@ RppStatus tensor_mean_u8_f32_host(Rpp8u *srcPtr,
             Rpp32u sumAvxG[8] = {0};
             Rpp32u sumAvxB[8] = {0};
 
-            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
             srcPtrRowR = srcPtrChannel;
             srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
             srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
@@ -700,7 +700,7 @@ RppStatus tensor_mean_i8_f32_host(Rpp8s *srcPtr,
             Rpp32s sumAvxG[8] = {0};
             Rpp32s sumAvxB[8] = {0};
 
-            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
             srcPtrRowR = srcPtrChannel;
             srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
             srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;

--- a/src/modules/tensor/cpu/kernel/tensor_mean.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_mean.cpp
@@ -34,10 +34,9 @@ RppStatus tensor_mean_u8_f32_host(Rpp8u *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -234,10 +233,9 @@ RppStatus tensor_mean_f32_f32_host(Rpp32f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -434,10 +432,9 @@ RppStatus tensor_mean_f16_f32_host(Rpp16f *srcPtr,
                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -633,10 +630,9 @@ RppStatus tensor_mean_i8_f32_host(Rpp8s *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/tensor_mean.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_mean.cpp
@@ -33,7 +33,7 @@ RppStatus tensor_mean_u8_f32_host(Rpp8u *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -233,7 +233,7 @@ RppStatus tensor_mean_f32_f32_host(Rpp32f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -433,7 +433,7 @@ RppStatus tensor_mean_f16_f32_host(Rpp16f *srcPtr,
                                    RppLayoutParams layoutParams,
                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -632,7 +632,7 @@ RppStatus tensor_mean_i8_f32_host(Rpp8s *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/tensor_min.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_min.cpp
@@ -176,7 +176,7 @@ RppStatus tensor_min_u8_u8_host(Rpp8u *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -373,7 +373,7 @@ RppStatus tensor_min_f32_f32_host(Rpp32f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -575,7 +575,7 @@ RppStatus tensor_min_f16_f16_host(Rpp16f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -777,7 +777,7 @@ RppStatus tensor_min_i8_i8_host(Rpp8s *srcPtr,
                                 RpptRoiType roiType,
                                 RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)

--- a/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
@@ -157,7 +157,7 @@ RppStatus tensor_stddev_u8_f32_host(Rpp8u *srcPtr,
             Rpp32f meanB     = meanTensor[idx + 2];
             Rpp32f meanImage = meanTensor[idx + 3];
 
-            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            Rpp8u *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
             srcPtrRowR = srcPtrChannel;
             srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
             srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;
@@ -940,7 +940,7 @@ RppStatus tensor_stddev_i8_f32_host(Rpp8s *srcPtr,
             Rpp32f meanB     = meanTensor[idx + 2] + 128;
             Rpp32f meanImage = meanTensor[idx + 3] + 128;
 
-            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB, *dstPtrRow;
+            Rpp8s *srcPtrRowR, *srcPtrRowG, *srcPtrRowB;
             srcPtrRowR = srcPtrChannel;
             srcPtrRowG = srcPtrRowR + srcDescPtr->strides.cStride;
             srcPtrRowB = srcPtrRowG + srcDescPtr->strides.cStride;

--- a/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
@@ -73,7 +73,7 @@ RppStatus tensor_stddev_u8_f32_host(Rpp8u *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -335,7 +335,7 @@ RppStatus tensor_stddev_f32_f32_host(Rpp32f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -596,7 +596,7 @@ RppStatus tensor_stddev_f16_f32_host(Rpp16f *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -859,7 +859,7 @@ RppStatus tensor_stddev_i8_f32_host(Rpp8s *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_stddev.cpp
@@ -74,10 +74,9 @@ RppStatus tensor_stddev_u8_f32_host(Rpp8u *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -336,10 +335,9 @@ RppStatus tensor_stddev_f32_f32_host(Rpp32f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -597,10 +595,9 @@ RppStatus tensor_stddev_f16_f32_host(Rpp16f *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -860,10 +857,9 @@ RppStatus tensor_stddev_i8_f32_host(Rpp8s *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/tensor_sum.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_sum.cpp
@@ -32,7 +32,7 @@ RppStatus tensor_sum_u8_u64_host(Rpp8u *srcPtr,
                                  RpptRoiType roiType,
                                  RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -225,7 +225,7 @@ RppStatus tensor_sum_f32_f32_host(Rpp32f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -417,7 +417,7 @@ RppStatus tensor_sum_f16_f32_host(Rpp16f *srcPtr,
                                   RpptRoiType roiType,
                                   RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)
@@ -608,7 +608,7 @@ RppStatus tensor_sum_i8_i64_host(Rpp8s *srcPtr,
                                  RpptRoiType roiType,
                                  RppLayoutParams layoutParams)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
 
     omp_set_dynamic(0);
 #pragma omp parallel for num_threads(srcDescPtr->n)

--- a/src/modules/tensor/cpu/kernel/tensor_sum.cpp
+++ b/src/modules/tensor/cpu/kernel/tensor_sum.cpp
@@ -629,7 +629,6 @@ RppStatus tensor_sum_i8_i64_host(Rpp8s *srcPtr,
         Rpp32u alignedLength = (bufferLength / 48) * 48;
         Rpp32u vectorIncrement = 48;
         Rpp32u vectorIncrementPerChannel = 16;
-        Rpp32u totalPixelsPerChannel = roi.xywhROI.roiWidth * roi.xywhROI.roiHeight;
 
         // Tensor Sum without fused output-layout toggle (NCHW)
         if ((srcDescPtr->c == 1) && (srcDescPtr->layout == RpptLayout::NCHW))

--- a/src/modules/tensor/cpu/kernel/threshold.cpp
+++ b/src/modules/tensor/cpu/kernel/threshold.cpp
@@ -71,7 +71,7 @@ RppStatus threshold_u8_u8_host_tensor(Rpp8u *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -370,7 +370,7 @@ RppStatus threshold_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -669,7 +669,7 @@ RppStatus threshold_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       RppLayoutParams layoutParams,
                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -968,7 +968,7 @@ RppStatus threshold_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         RppLayoutParams layoutParams,
                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/threshold.cpp
+++ b/src/modules/tensor/cpu/kernel/threshold.cpp
@@ -72,10 +72,9 @@ RppStatus threshold_u8_u8_host_tensor(Rpp8u *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -371,10 +370,9 @@ RppStatus threshold_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -670,10 +668,9 @@ RppStatus threshold_i8_i8_host_tensor(Rpp8s *srcPtr,
                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -969,10 +966,9 @@ RppStatus threshold_f16_f16_host_tensor(Rpp16f *srcPtr,
                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/to_decibels.cpp
+++ b/src/modules/tensor/cpu/kernel/to_decibels.cpp
@@ -34,8 +34,6 @@ RppStatus to_decibels_host_tensor(Rpp32f *srcPtr,
                                   Rpp32f referenceMagnitude,
                                   rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
-
     // Calculate the intermediate values needed for DB conversion
     Rpp32f minRatio = std::pow(10, cutOffDB / multiplier);
     if(minRatio == 0.0f)
@@ -45,7 +43,8 @@ RppStatus to_decibels_host_tensor(Rpp32f *srcPtr,
     multiplier *= log10Factor;
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < srcDescPtr->n; batchCount++)
     {
         Rpp32f *srcPtrCurrent = srcPtr + batchCount * srcDescPtr->strides.nStride;

--- a/src/modules/tensor/cpu/kernel/transpose.cpp
+++ b/src/modules/tensor/cpu/kernel/transpose.cpp
@@ -192,12 +192,12 @@ RppStatus transpose_f32_f32_host_tensor(Rpp32f *srcPtr,
                                         Rpp32u *roiTensor,
                                         rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = dstGenericDescPtr->numDims - 1;  // exclude batchsize from input dims
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         Rpp32f *srcPtrTemp, *dstPtrTemp;
@@ -416,12 +416,12 @@ RppStatus transpose_generic_host_tensor(T *srcPtr,
                                         Rpp32u *roiTensor,
                                         rpp::Handle& handle)
 {
-    Rpp32u numThreads = handle.GetNumThreads();
     Rpp32u tensorDims = dstGenericDescPtr->numDims - 1;  // exclude batchsize from input dims
     Rpp32u batchSize = dstGenericDescPtr->dims[0];
 
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < batchSize; batchCount++)
     {
         T *srcPtrTemp, *dstPtrTemp;

--- a/src/modules/tensor/cpu/kernel/transpose.cpp
+++ b/src/modules/tensor/cpu/kernel/transpose.cpp
@@ -324,8 +324,6 @@ RppStatus transpose_f32_f32_host_tensor(Rpp32f *srcPtr,
                 // Optimized AVX version for 3D inputs and permutation order (0, 2, 1)
                 else if(perm[0] == 0 && perm[1] == 2 && perm[2] == 1)
                 {
-                    Rpp32f *srcPtrRow = srcPtrTemp;
-                    Rpp32f *dstPtrRow = dstPtrTemp;
                     for(int i = 0; i < length[0]; i++)
                     {
                         compute_2d_pln1_transpose(srcPtrTemp, dstPtrTemp, length[1], length[2], srcGenericDescPtr->strides[2], dstGenericDescPtr->strides[2]);

--- a/src/modules/tensor/cpu/kernel/vignette.cpp
+++ b/src/modules/tensor/cpu/kernel/vignette.cpp
@@ -80,10 +80,9 @@ RppStatus vignette_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -386,10 +385,9 @@ RppStatus vignette_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -692,10 +690,9 @@ RppStatus vignette_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;
@@ -1017,10 +1014,9 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi;

--- a/src/modules/tensor/cpu/kernel/vignette.cpp
+++ b/src/modules/tensor/cpu/kernel/vignette.cpp
@@ -79,7 +79,7 @@ RppStatus vignette_u8_u8_host_tensor(Rpp8u *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -385,7 +385,7 @@ RppStatus vignette_f32_f32_host_tensor(Rpp32f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -691,7 +691,7 @@ RppStatus vignette_i8_i8_host_tensor(Rpp8s *srcPtr,
                                      RppLayoutParams layoutParams,
                                      rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1016,7 +1016,7 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                                        RppLayoutParams layoutParams,
                                        rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/warp_affine.cpp
+++ b/src/modules/tensor/cpu/kernel/warp_affine.cpp
@@ -73,10 +73,9 @@ RppStatus warp_affine_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -300,10 +299,9 @@ RppStatus warp_affine_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -527,10 +525,9 @@ RppStatus warp_affine_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -754,10 +751,9 @@ RppStatus warp_affine_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -898,10 +894,9 @@ RppStatus warp_affine_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1168,10 +1163,9 @@ RppStatus warp_affine_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1437,10 +1431,9 @@ RppStatus warp_affine_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                  rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1711,10 +1704,9 @@ RppStatus warp_affine_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                    rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;

--- a/src/modules/tensor/cpu/kernel/warp_affine.cpp
+++ b/src/modules/tensor/cpu/kernel/warp_affine.cpp
@@ -72,7 +72,7 @@ RppStatus warp_affine_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                            RppLayoutParams srcLayoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -299,7 +299,7 @@ RppStatus warp_affine_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                              RppLayoutParams srcLayoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -526,7 +526,7 @@ RppStatus warp_affine_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                            RppLayoutParams srcLayoutParams,
                                            rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -753,7 +753,7 @@ RppStatus warp_affine_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                              RppLayoutParams srcLayoutParams,
                                              rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -897,7 +897,7 @@ RppStatus warp_affine_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                  RppLayoutParams srcLayoutParams,
                                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1167,7 +1167,7 @@ RppStatus warp_affine_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                    RppLayoutParams srcLayoutParams,
                                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1436,7 +1436,7 @@ RppStatus warp_affine_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                  RppLayoutParams srcLayoutParams,
                                                  rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1710,7 +1710,7 @@ RppStatus warp_affine_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                    RppLayoutParams srcLayoutParams,
                                                    rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/warp_affine.cpp
+++ b/src/modules/tensor/cpu/kernel/warp_affine.cpp
@@ -807,10 +807,6 @@ RppStatus warp_affine_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
         {
             Rpp16f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp16f *srcPtrChannelR, *srcPtrChannelG, *srcPtrChannelB;
-            srcPtrChannelR = srcPtrChannel;
-            srcPtrChannelG = srcPtrChannelR + srcDescPtr->strides.cStride;
-            srcPtrChannelB = srcPtrChannelG + srcDescPtr->strides.cStride;
 
             for(int i = 0; i < roi.xywhROI.roiHeight; i++)
             {
@@ -922,10 +918,6 @@ RppStatus warp_affine_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
 
         __m256 pBilinearCoeffs[4];
         __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
-        __m256 pAffineMatrixTerm0 = _mm256_setr_ps(0, affineMatrix_f6->data[0], affineMatrix_f6->data[0] * 2, affineMatrix_f6->data[0] * 3, affineMatrix_f6->data[0] * 4, affineMatrix_f6->data[0] * 5, affineMatrix_f6->data[0] * 6, affineMatrix_f6->data[0] * 7);
-        __m256 pAffineMatrixTerm3 = _mm256_setr_ps(0, affineMatrix_f6->data[3], affineMatrix_f6->data[3] * 2, affineMatrix_f6->data[3] * 3, affineMatrix_f6->data[3] * 4, affineMatrix_f6->data[3] * 5, affineMatrix_f6->data[3] * 6, affineMatrix_f6->data[3] * 7);
-        __m256 pAffineMatrixTerm0Incr = _mm256_set1_ps(affineMatrix_f6->data[0] * 8);
-        __m256 pAffineMatrixTerm3Incr = _mm256_set1_ps(affineMatrix_f6->data[3] * 8);
         __m256 pAffineMatrix0 = _mm256_set1_ps(affineMatrix_f6->data[0]);
         __m256 pAffineMatrix3 = _mm256_set1_ps(affineMatrix_f6->data[3]);
         __m256 pRoiLTRB[4];
@@ -1191,10 +1183,6 @@ RppStatus warp_affine_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
 
         __m256 pBilinearCoeffs[4];
         __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
-        __m256 pAffineMatrixTerm0 = _mm256_setr_ps(0, affineMatrix_f6->data[0], affineMatrix_f6->data[0] * 2, affineMatrix_f6->data[0] * 3, affineMatrix_f6->data[0] * 4, affineMatrix_f6->data[0] * 5, affineMatrix_f6->data[0] * 6, affineMatrix_f6->data[0] * 7);
-        __m256 pAffineMatrixTerm3 = _mm256_setr_ps(0, affineMatrix_f6->data[3], affineMatrix_f6->data[3] * 2, affineMatrix_f6->data[3] * 3, affineMatrix_f6->data[3] * 4, affineMatrix_f6->data[3] * 5, affineMatrix_f6->data[3] * 6, affineMatrix_f6->data[3] * 7);
-        __m256 pAffineMatrixTerm0Incr = _mm256_set1_ps(affineMatrix_f6->data[0] * 8);
-        __m256 pAffineMatrixTerm3Incr = _mm256_set1_ps(affineMatrix_f6->data[3] * 8);
         __m256 pAffineMatrix0 = _mm256_set1_ps(affineMatrix_f6->data[0]);
         __m256 pAffineMatrix3 = _mm256_set1_ps(affineMatrix_f6->data[3]);
         __m256 pRoiLTRB[4];
@@ -1459,10 +1447,6 @@ RppStatus warp_affine_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
 
         __m256 pBilinearCoeffs[4];
         __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
-        __m256 pAffineMatrixTerm0 = _mm256_setr_ps(0, affineMatrix_f6->data[0], affineMatrix_f6->data[0] * 2, affineMatrix_f6->data[0] * 3, affineMatrix_f6->data[0] * 4, affineMatrix_f6->data[0] * 5, affineMatrix_f6->data[0] * 6, affineMatrix_f6->data[0] * 7);
-        __m256 pAffineMatrixTerm3 = _mm256_setr_ps(0, affineMatrix_f6->data[3], affineMatrix_f6->data[3] * 2, affineMatrix_f6->data[3] * 3, affineMatrix_f6->data[3] * 4, affineMatrix_f6->data[3] * 5, affineMatrix_f6->data[3] * 6, affineMatrix_f6->data[3] * 7);
-        __m256 pAffineMatrixTerm0Incr = _mm256_set1_ps(affineMatrix_f6->data[0] * 8);
-        __m256 pAffineMatrixTerm3Incr = _mm256_set1_ps(affineMatrix_f6->data[3] * 8);
         __m256 pAffineMatrix0 = _mm256_set1_ps(affineMatrix_f6->data[0]);
         __m256 pAffineMatrix3 = _mm256_set1_ps(affineMatrix_f6->data[3]);
         __m256 pRoiLTRB[4];
@@ -1732,10 +1716,6 @@ RppStatus warp_affine_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
 
         __m256 pBilinearCoeffs[4];
         __m256 pSrcStrideH = _mm256_set1_ps(srcDescPtr->strides.hStride);
-        __m256 pAffineMatrixTerm0 = _mm256_setr_ps(0, affineMatrix_f6->data[0], affineMatrix_f6->data[0] * 2, affineMatrix_f6->data[0] * 3, affineMatrix_f6->data[0] * 4, affineMatrix_f6->data[0] * 5, affineMatrix_f6->data[0] * 6, affineMatrix_f6->data[0] * 7);
-        __m256 pAffineMatrixTerm3 = _mm256_setr_ps(0, affineMatrix_f6->data[3], affineMatrix_f6->data[3] * 2, affineMatrix_f6->data[3] * 3, affineMatrix_f6->data[3] * 4, affineMatrix_f6->data[3] * 5, affineMatrix_f6->data[3] * 6, affineMatrix_f6->data[3] * 7);
-        __m256 pAffineMatrixTerm0Incr = _mm256_set1_ps(affineMatrix_f6->data[0] * 8);
-        __m256 pAffineMatrixTerm3Incr = _mm256_set1_ps(affineMatrix_f6->data[3] * 8);
         __m256 pAffineMatrix0 = _mm256_set1_ps(affineMatrix_f6->data[0]);
         __m256 pAffineMatrix3 = _mm256_set1_ps(affineMatrix_f6->data[3]);
         __m256 pRoiLTRB[4];

--- a/src/modules/tensor/cpu/kernel/warp_perspective.cpp
+++ b/src/modules/tensor/cpu/kernel/warp_perspective.cpp
@@ -77,10 +77,9 @@ RppStatus warp_perspective_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -321,10 +320,9 @@ RppStatus warp_perspective_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -565,10 +563,9 @@ RppStatus warp_perspective_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                 rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -809,10 +806,9 @@ RppStatus warp_perspective_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1052,10 +1048,9 @@ RppStatus warp_perspective_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1339,10 +1334,9 @@ RppStatus warp_perspective_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1626,10 +1620,9 @@ RppStatus warp_perspective_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                       rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -1918,10 +1911,9 @@ RppStatus warp_perspective_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                         rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;

--- a/src/modules/tensor/cpu/kernel/warp_perspective.cpp
+++ b/src/modules/tensor/cpu/kernel/warp_perspective.cpp
@@ -76,7 +76,7 @@ RppStatus warp_perspective_nn_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                 RppLayoutParams srcLayoutParams,
                                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -320,7 +320,7 @@ RppStatus warp_perspective_nn_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                   RppLayoutParams srcLayoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -564,7 +564,7 @@ RppStatus warp_perspective_nn_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                 RppLayoutParams srcLayoutParams,
                                                 rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -808,7 +808,7 @@ RppStatus warp_perspective_nn_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                   RppLayoutParams srcLayoutParams,
                                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1051,7 +1051,7 @@ RppStatus warp_perspective_bilinear_u8_u8_host_tensor(Rpp8u *srcPtr,
                                                       RppLayoutParams srcLayoutParams,
                                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1338,7 +1338,7 @@ RppStatus warp_perspective_bilinear_f32_f32_host_tensor(Rpp32f *srcPtr,
                                                         RppLayoutParams srcLayoutParams,
                                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1625,7 +1625,7 @@ RppStatus warp_perspective_bilinear_i8_i8_host_tensor(Rpp8s *srcPtr,
                                                       RppLayoutParams srcLayoutParams,
                                                       rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -1917,7 +1917,7 @@ RppStatus warp_perspective_bilinear_f16_f16_host_tensor(Rpp16f *srcPtr,
                                                         RppLayoutParams srcLayoutParams,
                                                         rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, (Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h};
+    RpptROI roiDefault = rpp_make_roi_xywh_full((Rpp32s)srcDescPtr->w, (Rpp32s)srcDescPtr->h);
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/water.cpp
+++ b/src/modules/tensor/cpu/kernel/water.cpp
@@ -57,7 +57,7 @@ RppStatus water_u8_u8_host_tensor(Rpp8u *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h)};
+    RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -318,7 +318,7 @@ RppStatus water_f32_f32_host_tensor(Rpp32f *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h)};
+    RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -579,7 +579,7 @@ RppStatus water_f16_f16_host_tensor(Rpp16f *srcPtr,
                                     RppLayoutParams layoutParams,
                                     rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h)};
+    RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);
@@ -742,7 +742,7 @@ RppStatus water_i8_i8_host_tensor(Rpp8s *srcPtr,
                                   RppLayoutParams layoutParams,
                                   rpp::Handle& handle)
 {
-    RpptROI roiDefault = {0, 0, static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h)};
+    RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
     Rpp32u numThreads = handle.GetNumThreads();
 
     omp_set_dynamic(0);

--- a/src/modules/tensor/cpu/kernel/water.cpp
+++ b/src/modules/tensor/cpu/kernel/water.cpp
@@ -58,10 +58,9 @@ RppStatus water_u8_u8_host_tensor(Rpp8u *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -319,10 +318,9 @@ RppStatus water_f32_f32_host_tensor(Rpp32f *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -580,10 +578,9 @@ RppStatus water_f16_f16_host_tensor(Rpp16f *srcPtr,
                                     rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;
@@ -743,10 +740,9 @@ RppStatus water_i8_i8_host_tensor(Rpp8s *srcPtr,
                                   rpp::Handle& handle)
 {
     RpptROI roiDefault = rpp_make_roi_xywh_full(static_cast<Rpp32s>(srcDescPtr->w), static_cast<Rpp32s>(srcDescPtr->h));
-    Rpp32u numThreads = handle.GetNumThreads();
-
     omp_set_dynamic(0);
-#pragma omp parallel for num_threads(numThreads)
+    omp_set_num_threads(handle.GetNumThreads());
+#pragma omp parallel for
     for(int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {
         RpptROI roi, roiLTRB;

--- a/src/modules/tensor/hip/kernel/color_space_conversion.cpp
+++ b/src/modules/tensor/hip/kernel/color_space_conversion.cpp
@@ -135,9 +135,9 @@ static void rpp_nv12_set_mat_yuv2rgb(RpptColorStandard col_standard, RpptColorRa
         break;
     }
     float mat[3][3] = {
-        1.0f, 0.0f, (1.0f - wr) / 0.5f,
-        1.0f, -wb * (1.0f - wb) / 0.5f / (1 - wb - wr), -wr * (1 - wr) / 0.5f / (1 - wb - wr),
-        1.0f, (1.0f - wb) / 0.5f, 0.0f,
+        {1.0f, 0.0f, (1.0f - wr) / 0.5f},
+        {1.0f, -wb * (1.0f - wb) / 0.5f / (1 - wb - wr), -wr * (1 - wr) / 0.5f / (1 - wb - wr)},
+        {1.0f, (1.0f - wb) / 0.5f, 0.0f},
     };
     for (int i = 0; i < 3; i++)
         for (int j = 0; j < 3; j++)

--- a/src/modules/tensor/hip/kernel/histogram_equalize.cpp
+++ b/src/modules/tensor/hip/kernel/histogram_equalize.cpp
@@ -437,7 +437,7 @@ RppStatus hip_exec_histogram_equalize_tensor(Rpp8u *srcPtr,
                                roiTensorPtrSrc,
                                batchSize);
 
-            hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream());
+            CHECK_RETURN_STATUS(hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream()));
 
             globalThreads_x = srcDescPtr->w;
             hipLaunchKernelGGL(collect_hist_pln_hip_tensor,
@@ -520,7 +520,7 @@ RppStatus hip_exec_histogram_equalize_tensor(Rpp8u *srcPtr,
                                make_ulong2(yuvNStride, yuvHStride),
                                roiTensorPtrSrc, batchSize);
 
-            hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream());
+            CHECK_RETURN_STATUS(hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream()));
 
             globalThreads_x = srcDescPtr->w;
             hipLaunchKernelGGL(collect_hist_pln_hip_tensor,
@@ -587,7 +587,7 @@ RppStatus hip_exec_histogram_equalize_tensor(Rpp8u *srcPtr,
     }
 
     // Single channel processing
-    hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream());
+    CHECK_RETURN_STATUS(hipMemsetAsync(d_hist, 0, batchSize * HISTOGRAM_BINS * sizeof(unsigned int), handle.GetStream()));
 
     int globalThreads_x = srcDescPtr->w;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -197,7 +197,6 @@ __device__ inline void dct_fwd_8x8_1d(float *vec, bool offset128)
 __device__ inline void dct_inv_8x8_1d(float *vec, bool offset128)
 {
     int val = (128.0f * offset128);
-    float4 val4 = MAKE_FLOAT4((float)val);
 
     // Load data into float4 vectors
     float4 vec1_f4 = *(float4*)&vec[0];
@@ -916,7 +915,6 @@ __global__ void jpeg_compression_distortion_pln1_hip_tensor(T *srcPtr,
     float qScale = get_quality_factor(qualityTensor[id_z]);
 
     int hipThreadIdx_x8 = hipThreadIdx_x * 8;
-    int hipThreadIdx_x4 = hipThreadIdx_x * 4;
 
     int alignedWidth = (roiTensorPtrSrc[id_z].xywhROI.roiWidth + 15) & ~15;
     int alignedHeight = (roiTensorPtrSrc[id_z].xywhROI.roiHeight + 15) & ~15;

--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -933,7 +933,7 @@ __global__ void jpeg_compression_distortion_pln1_hip_tensor(T *srcPtr,
 
     // Shared memory declaration
     __shared__ float src_smem[16][128];  // Assuming 16 rows (aligned height for 1 channel)
-    d_float8 zeroes_f8 = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    d_float8 zeroes_f8 = {{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}};
     *(d_float8*)&src_smem[hipThreadIdx_y][hipThreadIdx_x8] = zeroes_f8;
     __syncthreads();
 

--- a/src/modules/tensor/hip/kernel/noise_gaussian.cpp
+++ b/src/modules/tensor/hip/kernel/noise_gaussian.cpp
@@ -57,7 +57,7 @@ __device__ void gaussian_noise_24_hip_compute(d_float24 *pix_f24, RpptXorwowStat
 
 __device__ void gaussian_noise_voxel_8_hip_compute(d_float8 *pix_f8, RpptXorwowStateBoxMuller *xorwowState, float mean, float stdDev)
 {
-    d_float8 rngVals_f8, pixSqrt_f8;
+    d_float8 rngVals_f8;
     rpp_hip_rng_8_gaussian_f32(&rngVals_f8, xorwowState);
     rpp_hip_math_multiply8_const(&rngVals_f8, &rngVals_f8, MAKE_FLOAT4(stdDev));
     rpp_hip_math_add8_const(&rngVals_f8, &rngVals_f8, MAKE_FLOAT4(mean));
@@ -66,7 +66,7 @@ __device__ void gaussian_noise_voxel_8_hip_compute(d_float8 *pix_f8, RpptXorwowS
 
 __device__ void gaussian_noise_voxel_24_hip_compute(d_float24 *pix_f24, RpptXorwowStateBoxMuller *xorwowState, float mean, float stdDev)
 {
-    d_float24 rngVals_f24, pixSqrt_f24;
+    d_float24 rngVals_f24;
     rpp_hip_rng_8_gaussian_f32(&rngVals_f24.f8[0], xorwowState);
     rpp_hip_rng_8_gaussian_f32(&rngVals_f24.f8[1], xorwowState);
     rpp_hip_rng_8_gaussian_f32(&rngVals_f24.f8[2], xorwowState);

--- a/src/modules/tensor/hip/kernel/non_silent_region_detection.cpp
+++ b/src/modules/tensor/hip/kernel/non_silent_region_detection.cpp
@@ -101,7 +101,6 @@ __global__ void moving_mean_square_hip_tensor(float *srcPtr,
                                               float windowFactor,
                                               int inputTileLength)
 {
-    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
     int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
     uint srcLength = srcLengthTensor[id_z];
     uint batchStride = id_z * nStride;

--- a/src/modules/tensor/hip/kernel/normalize.cpp
+++ b/src/modules/tensor/hip/kernel/normalize.cpp
@@ -1544,7 +1544,7 @@ RppStatus hip_exec_compute_mean_stddev_tensor(T *srcPtr,
                                               rpp::Handle& handle)
 {
     Rpp32f *partialSumArr = handle.GetInitHandle()->mem.mgpu.scratchBufferHip.floatmem;
-    Rpp32u partialSumArrLength, partialSumBlocksPerSample;
+    Rpp32u partialSumBlocksPerSample;
 
     int globalThreads_x, globalThreads_y, globalThreads_z;
     int localThreads_x, localThreads_y, localThreads_z;
@@ -1733,7 +1733,6 @@ RppStatus hip_exec_compute_mean_stddev_tensor(T *srcPtr,
         globalThreads_x = srcGenericDescPtr->strides[0];
         globalThreads_y = 1;
         globalThreads_z = srcGenericDescPtr->dims[0];
-        Rpp32u batchSize = globalThreads_z;
 
         // allocate tensor for src strides
         Rpp32u *srcMaxDims = &srcGenericDescPtr->dims[1];

--- a/src/modules/tensor/hip/kernel/ricap.cpp
+++ b/src/modules/tensor/hip/kernel/ricap.cpp
@@ -52,6 +52,8 @@ __global__ void ricap_pkd_tensor(T *srcPtr,
         srcIdx = (permutedIndices[permuteIdx + 2] * srcStridesNH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[2].xywhROI.xy.y) * srcStridesNH.y) + (id_x + (cropRegion[2].xywhROI.xy.x) * 3);
     else if ((id_y >= cropRegion[1].xywhROI.roiHeight) && (id_x >= cropRegion[2].xywhROI.roiWidth * 3))
         srcIdx = (permutedIndices[permuteIdx + 3] * srcStridesNH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[3].xywhROI.xy.y) * srcStridesNH.y) + (id_x - (cropRegion[2].xywhROI.roiWidth) * 3 + (cropRegion[3].xywhROI.xy.x) * 3);
+    else
+        return;
 
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x;
 
@@ -89,6 +91,8 @@ __global__ void ricap_pln_tensor(T *srcPtr,
         srcIdx = (permutedIndices[permuteIdx + 2] * srcStridesNCH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[2].xywhROI.xy.y) * srcStridesNCH.z) + (id_x + cropRegion[2].xywhROI.xy.x);
     else if ((id_y >= cropRegion[1].xywhROI.roiHeight) && (id_x >= cropRegion[2].xywhROI.roiWidth))
         srcIdx = (permutedIndices[permuteIdx + 3] * srcStridesNCH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[3].xywhROI.xy.y) * srcStridesNCH.z) + (id_x - cropRegion[2].xywhROI.roiWidth + cropRegion[3].xywhROI.xy.x);
+    else
+        return;
 
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
@@ -140,6 +144,8 @@ __global__ void ricap_pkd3_pln3_tensor(T *srcPtr,
         srcIdx = (permutedIndices[permuteIdx + 2] * srcStridesNH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[2].xywhROI.xy.y) * srcStridesNH.y) + ((id_x + cropRegion[2].xywhROI.xy.x)*3);
     else if ((id_y >= cropRegion[1].xywhROI.roiHeight) && (id_x >= cropRegion[2].xywhROI.roiWidth))
         srcIdx = (permutedIndices[permuteIdx + 3] * srcStridesNH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[3].xywhROI.xy.y) * srcStridesNH.y) + ((id_x - cropRegion[2].xywhROI.roiWidth + cropRegion[3].xywhROI.xy.x)*3);
+    else
+        return;
 
     uint dstIdx = (id_z * dstStridesNCH.x) + (id_y * dstStridesNCH.z) + id_x;
 
@@ -176,6 +182,8 @@ __global__ void ricap_pln3_pkd3_tensor(T *srcPtr,
         srcIdx = (permutedIndices[permuteIdx + 2] * srcStridesNCH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[2].xywhROI.xy.y) * srcStridesNCH.z) + (id_x + cropRegion[2].xywhROI.xy.x);
     else if ((id_y >= cropRegion[1].xywhROI.roiHeight) && (id_x >= cropRegion[2].xywhROI.roiWidth))
         srcIdx = (permutedIndices[permuteIdx + 3] * srcStridesNCH.x) + ((id_y - cropRegion[1].xywhROI.roiHeight + cropRegion[3].xywhROI.xy.y) * srcStridesNCH.z) + (id_x - cropRegion[2].xywhROI.roiWidth + cropRegion[3].xywhROI.xy.x);
+    else
+        return;
 
     uint dstIdx = (id_z * dstStridesNH.x) + (id_y * dstStridesNH.y) + id_x * 3;
 

--- a/src/modules/tensor/hip/kernel/slice.cpp
+++ b/src/modules/tensor/hip/kernel/slice.cpp
@@ -278,8 +278,6 @@ RppStatus hip_exec_fill_value_tensor(T *dstPtr,
             Rpp32s *shape = &shapeTensor[batchCount * numDims];
             Rpp32u *roi = roiTensor + batchCount * numDims * 2;
             Rpp32s *length = reinterpret_cast<Rpp32s *>(&roi[numDims]);
-            Rpp32u maxHeight = std::min(shape[0], length[0] - anchor[0]);
-            Rpp32u maxWidth = std::min(shape[1], length[1] - anchor[1]);
 
             // check if padding is needed
             bool needPadding = (((anchor[0] + shape[0]) > length[0]) ||
@@ -314,7 +312,6 @@ RppStatus hip_exec_fill_value_tensor(T *dstPtr,
             Rpp32s *shape = &shapeTensor[batchCount * numDims];
             Rpp32u *roi = roiTensor + batchCount * numDims * 2;
             Rpp32s *length = reinterpret_cast<Rpp32s *>(&roi[numDims]);
-            Rpp32u maxLength = std::min(shape[0], length[0] - anchor[0]);
 
             // check if padding is needed
             bool needPadding = ((anchor[0] + shape[0]) > length[0]);

--- a/src/modules/tensor/hip/kernel/to_decibels.cpp
+++ b/src/modules/tensor/hip/kernel/to_decibels.cpp
@@ -94,7 +94,6 @@ __global__ void max_reduction_1d_hip_tensor(float *srcPtr,
                                             RpptImagePatchPtr srcDims,
                                             float *maxArr)
 {
-    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
     int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
     int id_x = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x) * 8;
 

--- a/src/modules/tensor/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_effects_augmentations.cpp
@@ -2499,7 +2499,7 @@ RppStatus rppt_fog(RppPtr_t srcPtr,
         Rpp32u maskSizeInBytes = maskSize * sizeof(Rpp32f);
 
         // Copying fog alpha mask from host to device asynchronously
-        Rpp32f *d_fogAlphaMaskPtr, *d_fogIntensityMaskPtr, *d_resizedFogAlphaMaskPtr, *d_resizedFogIntensityMaskPtr;
+        Rpp32f *d_fogAlphaMaskPtr, *d_resizedFogAlphaMaskPtr, *d_resizedFogIntensityMaskPtr;
         d_fogAlphaMaskPtr = reinterpret_cast<Rpp32f*>(handle.GetInitHandle()->mem.mgpu.scratchBufferHip.floatmem);
         d_resizedFogAlphaMaskPtr = reinterpret_cast<Rpp32f*>(d_fogAlphaMaskPtr + (2 * maskSize));
         d_resizedFogIntensityMaskPtr = d_resizedFogAlphaMaskPtr + (srcDescPtr->h * srcDescPtr->w);

--- a/src/modules/tensor/rppt_tensor_effects_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_effects_augmentations.cpp
@@ -2392,7 +2392,7 @@ RppStatus rppt_fog(RppPtr_t srcPtr,
         for (Rpp32s i = 0; i < 2; i++)
         {
             internalDstImgSizes[i] = {srcDescPtr->w, srcDescPtr->h};
-            internalRoiTensorPtrSrc[i].xywhROI = {0, 0, 1920, 1080};
+            internalRoiTensorPtrSrc[i].xywhROI = {{0, 0}, 1920, 1080};
         }
         RpptInterpolationType interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
         Rpp32f *resizedFogAlphaMaskPtr = reinterpret_cast<Rpp32f *>(internalRoiTensorPtrSrc + 2);
@@ -2487,7 +2487,7 @@ RppStatus rppt_fog(RppPtr_t srcPtr,
         for (Rpp32s i = 0; i < 2; i++)
         {
             internalDstImgSizes[i] = {srcDescPtr->w, srcDescPtr->h};
-            internalRoiTensorPtrSrc[i].xywhROI = {0, 0, 1920, 1080};
+            internalRoiTensorPtrSrc[i].xywhROI = {{0, 0}, 1920, 1080};
         }
         RpptInterpolationType interpolationType = RpptInterpolationType::NEAREST_NEIGHBOR;
 


### PR DESCRIPTION
## Description
Removes remaining `-Wall` warnings from RPP's codebase. Since this changes many files, it will require a more in-depth review to ensure that no correctness errors arise.

Note that `-Wvla-cxx-extension` is being suppressed, since this must be compiled with a Clang compiler regardless. `amdclang++` supports variable length arrays, even though this isn't a C++ standard.

This branch is based on `zv/bugfix/resolve-warnings-phase-1`, and must be rebased once that PR is merged into develop. This is why the diff (compared to develop) is very large. Keeping this as a draft PR for now until that branch gets merged in.

## Testing
Standard tests, via `ctest -VV` are all passing with these changes.
