### PR TITLE
Bug fix - Test suite - YUV to RGB

### DIFF
--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -104,8 +104,10 @@ inline bool filename_matches_requested_extension(const std::string& fileName, co
     if (ext.empty())
         return false;
     size_t dot = fileName.find_last_of('.');
-    if (dot == std::string::npos || dot + 1 >= fileName.size())
+    if (dot == std::string::npos || dot + 1 >= fileName.size()) {
+        std::cout << "ERROR: File name does not contain a valid extension: " << fileName << std::endl;
         return false;
+    }
     return fileName.compare(dot + 1, std::string::npos, ext) == 0;
 }
 

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -98,11 +98,15 @@ inline std::map<RppStatus, std::string> rppStatusToString = {
 // True if basename extension (substring after the last '.') matches extension without its leading dot (e.g. ".yuv" -> foo.nv12.yuv yes, foo.info no).
 inline bool filename_matches_requested_extension(const std::string& fileName, const std::string& extension)
 {
-    if (extension.empty() || extension[0] != '.')
+    if (extension.empty() || extension[0] != '.') {
+        std::cout << "ERROR: Extension is empty: " << extension << std::endl;
         return false;
+    }
     const std::string ext = extension.substr(1);
-    if (ext.empty())
+    if (ext.empty()) {
+        std::cout << "ERROR: Extension is empty: " << extension << std::endl;
         return false;
+    }
     size_t dot = fileName.find_last_of('.');
     if (dot == std::string::npos || dot + 1 >= fileName.size()) {
         std::cout << "ERROR: File name does not contain a valid extension: " << fileName << std::endl;

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -95,8 +95,21 @@ inline std::map<RppStatus, std::string> rppStatusToString = {
     {RPP_ERROR_INVALID_AXIS,                    "RPP_ERROR_INVALID_AXIS"}
 };
 
+// True if basename extension (substring after the last '.') matches extension without its leading dot (e.g. ".yuv" -> foo.nv12.yuv yes, foo.info no).
+inline bool filename_matches_requested_extension(const std::string& fileName, const std::string& extension)
+{
+    if (extension.empty() || extension[0] != '.')
+        return false;
+    const std::string ext = extension.substr(1);
+    if (ext.empty())
+        return false;
+    size_t dot = fileName.find_last_of('.');
+    if (dot == std::string::npos || dot + 1 >= fileName.size())
+        return false;
+    return fileName.compare(dot + 1, std::string::npos, ext) == 0;
+}
 
-// Opens a folder and recursively search for files with given extension
+// Opens a folder and recursively search for files with given extension (e.g. ".jpg", ".wav", ".yuv").
 void open_folder(const string& folderPath, vector<string>& imageNames, vector<string>& imageNamesPath, string extension)
 {
     auto src_dir = opendir(folderPath.c_str());
@@ -119,7 +132,7 @@ void open_folder(const string& folderPath, vector<string>& imageNames, vector<st
         if(fs::exists(pathObj) && fs::is_directory(pathObj))
             open_folder(filePath, imageNames, imageNamesPath, extension);
 
-        if (fileName.size() > 4 && fileName.substr(fileName.size() - 4) == extension)
+        if (filename_matches_requested_extension(fileName, extension))
         {
             imageNamesPath.push_back(filePath);
             imageNames.push_back(entity->d_name);
@@ -131,7 +144,7 @@ void open_folder(const string& folderPath, vector<string>& imageNames, vector<st
     closedir(src_dir);
 }
 
-// Searches for files with the provided extensions in input folders
+// Searches for files with the provided extensions in input folders.
 void search_files_recursive(const string& folder_path, vector<string>& imageNames, vector<string>& imageNamesPath, string extension)
 {
     vector<string> entry_list;
@@ -168,7 +181,7 @@ void search_files_recursive(const string& folder_path, vector<string>& imageName
                 if ((file_extension == "tar") || (file_extension == "zip") || (file_extension == "7z") || (file_extension == "rar"))
                     continue;
             }
-            if (entry_list[dir_count].size() > 4 && entry_list[dir_count].substr(entry_list[dir_count].size() - 4) == extension)
+            if (filename_matches_requested_extension(entry_list[dir_count], extension))
             {
                 imageNames.push_back(entry_list[dir_count]);
                 imageNamesPath.push_back(subfolder_path);


### PR DESCRIPTION
## Motivation

For ctest runs, the batch size for qa mode has to be 3. It iterates over 3 images as one batch. In the case of yuv to rgb, we have 3 yuv images and 3 .info files for it's width/ height and other meta  data. These files were being considered as input yuv and failed in
some batches. This PR fixes it to only take the yuv images for a batch in yuv to rgb

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

After building,
`make test ARGS="-I 5,5,5 -VV"`


## Test Result

Yuv_to_rgb should only run once upon ctest.

```
5: histogram_equalize_u8_Tensor_PKD3_to_PKD3: PASSED
5: histogram_equalize_u8_Tensor_PKD3_to_PLN3: PASSED
5: histogram_equalize_u8_Tensor_PLN3_to_PLN3: PASSED
5: histogram_equalize_u8_Tensor_PLN3_to_PKD3: PASSED
5: histogram_equalize_u8_Tensor_PLN1_to_PLN1: PASSED
5: yuv_to_rgb_u8_Tensor_PKD3_to_PKD3: PASSED
5:
5: ---------------------------------- Summary of QA Test - Tensor_image_hip ----------------------------------
5:
5: Final Results of Tests:
5:     - Total test cases including all subvariants REQUESTED = 901
5:     - Total test cases including all subvariants PASSED = 882
5:
5: General information on Tensor voxel test suite availability:
5:     - Total augmentations supported in Tensor test suite = 71
5:     - Total augmentations with golden output QA test support = 63
5:     - Total augmentations without golden ouput QA test support (due to randomization involved) = 8

```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
