### PR TITLE
Test Suite fixes

### DIFF
--- a/utilities/test_suite/HIP/Tensor_image_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_image_hip.cpp
@@ -2389,7 +2389,7 @@ int main(int argc, char **argv)
         CHECK_RETURN_STATUS(hipFree(d_input_second));
     CHECK_RETURN_STATUS(hipFree(d_output));
     if(testCase == PIXELATE)
-        CHECK_RETURN_STATUS(hipFree(d_interDstPtr));
+        CHECK_RETURN_STATUS(hipHostFree(d_interDstPtr));
     if(alpha != NULL)
         CHECK_RETURN_STATUS(hipHostFree(alpha));
     if(beta != NULL)
@@ -2465,6 +2465,8 @@ int main(int argc, char **argv)
         CHECK_RETURN_STATUS(hipHostFree(maxTensor));
     if (posterizeLevelBits != nullptr)
         CHECK_RETURN_STATUS(hipHostFree(posterizeLevelBits));
+    if (thresholdTensor != nullptr)
+        CHECK_RETURN_STATUS(hipHostFree(thresholdTensor));
     if(dropoutTensor != nullptr)
         CHECK_RETURN_STATUS(hipHostFree(dropoutTensor));
     if (permutationTensor != nullptr)

--- a/utilities/test_suite/HOST/Tensor_image_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_image_host.cpp
@@ -2210,7 +2210,7 @@ int main(int argc, char **argv)
     free(outputu8);
     free(input_second);
     free(output);
-    if(testCase == REMAP)
+    if(testCase == REMAP || testCase == LENS_CORRECTION)
     {
         free(rowRemapTable);
         free(colRemapTable);


### PR DESCRIPTION
## Motivation

Observed some mem allocs which were not released in the test suite, on both host and hip. This PR aims to fix the leaks

## Technical Details

Use hipHostFree and free to clean up memory allocations.

## Test Plan

Ctests should pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
