### PR TITLE
Jpeg QA failures sync fix

### DIFF
--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 - 2025 Advanced Micro Devices, Inc.
+Copyright (c) 2019 - 2026 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -357,9 +357,10 @@ __device__ __forceinline__ void process_jpeg_distortion(float src_smem[48][128],
     __syncthreads();
 
     // ----------- Step 2: Downsample CbCr -----------
+    float4 cb_f4 = {0.0f, 0.0f, 0.0f, 0.0f};
+    float4 cr_f4 = {0.0f, 0.0f, 0.0f, 0.0f};
     if (localThreadIdx_y < 8)
     {
-        float4 cb_f4, cr_f4;
         downsample_cbcr_hip_compute(
             (d_float8*)&src_smem[cbcrY][hipThreadIdx_x8],
             (d_float8*)&src_smem[cbcrY + 1][hipThreadIdx_x8],
@@ -368,7 +369,11 @@ __device__ __forceinline__ void process_jpeg_distortion(float src_smem[48][128],
             (d_float8*)&src_smem[cbcrY + 32][hipThreadIdx_x8],
             (d_float8*)&src_smem[cbcrY + 33][hipThreadIdx_x8],
             &cb_f4, &cr_f4);
+    }
+    __syncthreads();  // all smem reads must complete before any thread writes Cb/Cr back
 
+    if (localThreadIdx_y < 8)
+    {
         *(float4*)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x4] = cb_f4;
         *(float4*)&src_smem[8 + hipThreadIdx_y_channel.y][hipThreadIdx_x4] = cr_f4;
     }
@@ -433,7 +438,6 @@ __device__ __forceinline__ void process_jpeg_distortion(float src_smem[48][128],
     clamp_range((float*)&src_smem[hipThreadIdx_y_channel.y][hipThreadIdx_x8]);
     __syncthreads();
 
-    float4 cb_f4, cr_f4;
     cbcrY = localThreadIdx_y / 2;
     cb_f4 = *(float4*)&src_smem[cbcrY + 16][hipThreadIdx_x4];
     cr_f4 = *(float4*)&src_smem[cbcrY + 24][hipThreadIdx_x4];

--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -63,7 +63,7 @@ __device__ const float4 maxVal128_f4 = {128.0f, 128.0f, 128.0f, 128.0f};
 __device__ inline void clamp_range(schar *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 255.0f);
+        values[j] = __builtin_amdgcn_fmed3f(-128, values[j], 127);
 }
 
 // Clamping for float
@@ -84,7 +84,7 @@ __device__ inline void clamp_range(half *src, float* values)
 __device__ inline void clamp_range(uchar *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 255.0f);
+        values[j] = __builtin_amdgcn_fmed3f(0, values[j], 255);
 }
 
 // Generic clamping when no specific type is provided (default to 0-255)

--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -63,35 +63,35 @@ __device__ const float4 maxVal128_f4 = {128.0f, 128.0f, 128.0f, 128.0f};
 __device__ inline void clamp_range(schar *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = fminf(fmaxf(values[j], -128), 127);
+        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 255.0f);
 }
 
 // Clamping for float
 __device__ inline void clamp_range(float *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = fminf(fmaxf(values[j], 0.0f), 1.0f);
+        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 1.0f);
 }
 
 // Clamping for half
 __device__ inline void clamp_range(half *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = fminf(fmaxf(values[j], 0.0f), 1.0f);
+        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 1.0f);
 }
 
 // Clamping for unsigned char (uchar)
 __device__ inline void clamp_range(uchar *src, float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = fminf(fmaxf(values[j], 0), 255);
+        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 255.0f);
 }
 
 // Generic clamping when no specific type is provided (default to 0-255)
 __device__ inline void clamp_range(float* values)
 {
     for (int j = 0; j < 8; j++)
-        values[j] = fminf(fmaxf(values[j], 0.0f), 255.0f);
+        values[j] = __builtin_amdgcn_fmed3f(0.0f, values[j], 255.0f);
 }
 
 // Computing Y from R G B


### PR DESCRIPTION
## Motivation

JPEG QA test failures

## Technical Details

There was synchronization issue between shared memory read and write

## Test Plan
Build rpp and test with following command

rpp/utilities/test_suite/HIP# python3 runImageTests.py --case_list 93 --test_type 0 --qa_mode 1 --batch_size 3

The above test is carried out multiple number of times to verify randomness in the result and every time it succeeded.

## Test Result

Tested on gfx1201 Navi 4 card and following is the test result.

---------------------------------- Results of QA Test - Tensor_image_hip ----------------------------------

jpeg_compression_distortion_u8_Tensor_PKD3_to_PKD3: PASSED
jpeg_compression_distortion_u8_Tensor_PKD3_to_PLN3: PASSED
jpeg_compression_distortion_f32_Tensor_PKD3_to_PKD3: PASSED
jpeg_compression_distortion_f32_Tensor_PKD3_to_PLN3: PASSED
jpeg_compression_distortion_u8_Tensor_PLN3_to_PLN3: PASSED
jpeg_compression_distortion_u8_Tensor_PLN3_to_PKD3: PASSED
jpeg_compression_distortion_f32_Tensor_PLN3_to_PLN3: PASSED
jpeg_compression_distortion_f32_Tensor_PLN3_to_PKD3: PASSED
jpeg_compression_distortion_u8_Tensor_PLN1_to_PLN1: PASSED
jpeg_compression_distortion_f32_Tensor_PLN1_to_PLN1: PASSED

---------------------------------- Summary of QA Test - Tensor_image_hip ----------------------------------

Final Results of Tests:
    - Total test cases including all subvariants REQUESTED = 10
    - Total test cases including all subvariants PASSED = 10

General information on Tensor voxel test suite availability:
    - Total augmentations supported in Tensor test suite = 71
    - Total augmentations with golden output QA test support = 63
    - Total augmentations without golden ouput QA test support (due to randomization involved) = 8

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
