### PR TITLE
[WIP] Bug fix - HIP and HOST for crop mirror normalize

### DIFF
--- a/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
+++ b/src/modules/tensor/cpu/kernel/crop_mirror_normalize.cpp
@@ -23,6 +23,13 @@ SOFTWARE.
 */
 
 #include "host_tensor_executors.hpp"
+#include <cmath>
+
+// Scalar F32 CMN must match _mm256_fmadd_ps (one rounding); plain (a*b)+c can differ from FMA and across compilers.
+inline Rpp32f cmn_f32_fma(Rpp32f src, Rpp32f mul, Rpp32f off)
+{
+    return std::fma(src, mul, off);
+}
 
 inline void compute_cmn_48_host(__m256 *p, __m256 *pCMNParams)
 {
@@ -563,9 +570,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                     }
                     for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
                     {
-                        *dstPtrTempR = ((srcPtrTemp[0] * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        *dstPtrTempG = ((srcPtrTemp[1] * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        *dstPtrTempB = ((srcPtrTemp[2] * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        *dstPtrTempR = cmn_f32_fma(srcPtrTemp[0], multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        *dstPtrTempG = cmn_f32_fma(srcPtrTemp[1], multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        *dstPtrTempB = cmn_f32_fma(srcPtrTemp[2], multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
 
                         srcPtrTemp += 3;
                         dstPtrTempR++;
@@ -613,9 +620,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                     for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
                     {
                         srcPtrTemp -= 3;
-                        *dstPtrTempR = ((srcPtrTemp[0] * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        *dstPtrTempG = ((srcPtrTemp[1] * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        *dstPtrTempB = ((srcPtrTemp[2] * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        *dstPtrTempR = cmn_f32_fma(srcPtrTemp[0], multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        *dstPtrTempG = cmn_f32_fma(srcPtrTemp[1], multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        *dstPtrTempB = cmn_f32_fma(srcPtrTemp[2], multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
 
                         dstPtrTempR++;
                         dstPtrTempG++;
@@ -665,9 +672,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                     }
                     for (; vectorLoopCount < bufferLength; vectorLoopCount++)
                     {
-                        dstPtrTemp[0] = ((*srcPtrTempR * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        dstPtrTemp[1] = ((*srcPtrTempG * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        dstPtrTemp[2] = ((*srcPtrTempB * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        dstPtrTemp[0] = cmn_f32_fma(*srcPtrTempR, multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        dstPtrTemp[1] = cmn_f32_fma(*srcPtrTempG, multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        dstPtrTemp[2] = cmn_f32_fma(*srcPtrTempB, multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
 
                         srcPtrTempR++;
                         srcPtrTempG++;
@@ -718,9 +725,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                         srcPtrTempG--;
                         srcPtrTempB--;
 
-                        dstPtrTemp[0] = ((*srcPtrTempR * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        dstPtrTemp[1] = ((*srcPtrTempG * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        dstPtrTemp[2] = ((*srcPtrTempB * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        dstPtrTemp[0] = cmn_f32_fma(*srcPtrTempR, multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        dstPtrTemp[1] = cmn_f32_fma(*srcPtrTempG, multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        dstPtrTemp[2] = cmn_f32_fma(*srcPtrTempB, multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
 
                         dstPtrTemp += 3;
                     }
@@ -762,9 +769,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                     }
                     for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
                     {
-                        dstPtrTemp[0] = ((srcPtrTemp[0] * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        dstPtrTemp[1] = ((srcPtrTemp[1] * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        dstPtrTemp[2] = ((srcPtrTemp[2] * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        dstPtrTemp[0] = cmn_f32_fma(srcPtrTemp[0], multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        dstPtrTemp[1] = cmn_f32_fma(srcPtrTemp[1], multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        dstPtrTemp[2] = cmn_f32_fma(srcPtrTemp[2], multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
                         srcPtrTemp += 3;
                         dstPtrTemp += 3;
                     }
@@ -800,9 +807,9 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                     for (; vectorLoopCount < bufferLength; vectorLoopCount += 3)
                     {
                         srcPtrTemp -= 3;
-                        dstPtrTemp[0] = ((srcPtrTemp[0] * multiplierTensor[cmnParamLocs[0]]) + offsetTensor[cmnParamLocs[0]]);
-                        dstPtrTemp[1] = ((srcPtrTemp[1] * multiplierTensor[cmnParamLocs[1]]) + offsetTensor[cmnParamLocs[1]]);
-                        dstPtrTemp[2] = ((srcPtrTemp[2] * multiplierTensor[cmnParamLocs[2]]) + offsetTensor[cmnParamLocs[2]]);
+                        dstPtrTemp[0] = cmn_f32_fma(srcPtrTemp[0], multiplierTensor[cmnParamLocs[0]], offsetTensor[cmnParamLocs[0]]);
+                        dstPtrTemp[1] = cmn_f32_fma(srcPtrTemp[1], multiplierTensor[cmnParamLocs[1]], offsetTensor[cmnParamLocs[1]]);
+                        dstPtrTemp[2] = cmn_f32_fma(srcPtrTemp[2], multiplierTensor[cmnParamLocs[2]], offsetTensor[cmnParamLocs[2]]);
                         dstPtrTemp += 3;
                     }
                     srcPtrRow += srcDescPtr->strides.hStride;
@@ -843,7 +850,7 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                         }
                         for (; vectorLoopCount < bufferLength; vectorLoopCount++)
                         {
-                            *dstPtrTemp = ((*srcPtrTemp * multiplierTensor[cmnParamLocs[c]]) + offsetTensor[cmnParamLocs[c]]);
+                            *dstPtrTemp = cmn_f32_fma(*srcPtrTemp, multiplierTensor[cmnParamLocs[c]], offsetTensor[cmnParamLocs[c]]);
 
                             srcPtrTemp++;
                             dstPtrTemp++;
@@ -887,7 +894,7 @@ RppStatus crop_mirror_normalize_f32_f32_host_tensor(Rpp32f *srcPtr,
                         {
                             srcPtrTemp--;
 
-                            *dstPtrTemp = ((*srcPtrTemp * multiplierTensor[cmnParamLocs[c]]) + offsetTensor[cmnParamLocs[c]]);
+                            *dstPtrTemp = cmn_f32_fma(*srcPtrTemp, multiplierTensor[cmnParamLocs[c]], offsetTensor[cmnParamLocs[c]]);
                             dstPtrTemp++;
                         }
                         srcPtrRow += srcDescPtr->strides.hStride;

--- a/src/modules/tensor/hip/kernel/crop_mirror_normalize.cpp
+++ b/src/modules/tensor/hip/kernel/crop_mirror_normalize.cpp
@@ -24,39 +24,49 @@ SOFTWARE.
 
 #include "hip_tensor_executors.hpp"
 
+// F32 CMN must use one FMA rounding (matches HOST std::fma / AVX fmadd); plain (a*b)+c can differ.
+__device__ inline float4 cmn_f32_fma_float4(float4 src, float4 mul, float4 off)
+{
+    return make_float4(
+        fmaf(src.x, mul.x, off.x),
+        fmaf(src.y, mul.y, off.y),
+        fmaf(src.z, mul.z, off.z),
+        fmaf(src.w, mul.w, off.w));
+}
+
 __device__ void cmn_hip_compute(uchar *srcPtr, float *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = (pix_f8->f4[0] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
-    pix_f8->f4[1] = (pix_f8->f4[1] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
+    pix_f8->f4[0] = cmn_f32_fma_float4(pix_f8->f4[0], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
+    pix_f8->f4[1] = cmn_f32_fma_float4(pix_f8->f4[1], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
 }
 
 __device__ void cmn_hip_compute(uchar *srcPtr, half *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = (pix_f8->f4[0] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
-    pix_f8->f4[1] = (pix_f8->f4[1] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
+    pix_f8->f4[0] = cmn_f32_fma_float4(pix_f8->f4[0], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
+    pix_f8->f4[1] = cmn_f32_fma_float4(pix_f8->f4[1], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
 }
 
 __device__ void cmn_hip_compute(uchar *srcPtr, uchar *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = rpp_hip_pixel_check_0to255((pix_f8->f4[0] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1]);
-    pix_f8->f4[1] = rpp_hip_pixel_check_0to255((pix_f8->f4[1] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1]);
+    pix_f8->f4[0] = rpp_hip_pixel_check_0to255(cmn_f32_fma_float4(pix_f8->f4[0], cmnParams_f8->f4[0], cmnParams_f8->f4[1]));
+    pix_f8->f4[1] = rpp_hip_pixel_check_0to255(cmn_f32_fma_float4(pix_f8->f4[1], cmnParams_f8->f4[0], cmnParams_f8->f4[1]));
 }
 
 __device__ void cmn_hip_compute(float *srcPtr, float *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = (pix_f8->f4[0] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
-    pix_f8->f4[1] = (pix_f8->f4[1] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
+    pix_f8->f4[0] = cmn_f32_fma_float4(pix_f8->f4[0], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
+    pix_f8->f4[1] = cmn_f32_fma_float4(pix_f8->f4[1], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
 }
 
 __device__ void cmn_hip_compute(schar *srcPtr, schar *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = rpp_hip_pixel_check_0to255((pix_f8->f4[0] + FLOAT4_128) * cmnParams_f8->f4[0] +  cmnParams_f8->f4[1]) - FLOAT4_128;
-    pix_f8->f4[1] = rpp_hip_pixel_check_0to255((pix_f8->f4[1] + FLOAT4_128) * cmnParams_f8->f4[0] +  cmnParams_f8->f4[1]) - FLOAT4_128;
+    pix_f8->f4[0] = rpp_hip_pixel_check_0to255(cmn_f32_fma_float4(pix_f8->f4[0] + FLOAT4_128, cmnParams_f8->f4[0], cmnParams_f8->f4[1])) - FLOAT4_128;
+    pix_f8->f4[1] = rpp_hip_pixel_check_0to255(cmn_f32_fma_float4(pix_f8->f4[1] + FLOAT4_128, cmnParams_f8->f4[0], cmnParams_f8->f4[1])) - FLOAT4_128;
 }
 __device__ void cmn_hip_compute(half *srcPtr, half *dstPtr, d_float8 *pix_f8, d_float8 *cmnParams_f8)
 {
-    pix_f8->f4[0] = (pix_f8->f4[0] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
-    pix_f8->f4[1] = (pix_f8->f4[1] * cmnParams_f8->f4[0]) + cmnParams_f8->f4[1];
+    pix_f8->f4[0] = cmn_f32_fma_float4(pix_f8->f4[0], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
+    pix_f8->f4[1] = cmn_f32_fma_float4(pix_f8->f4[1], cmnParams_f8->f4[0], cmnParams_f8->f4[1]);
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
## Motivation

Creating this PR to check if it works to fix the failures on crop mirror normalize, since I cannot reproduce on Navi31 or MI325 system locally. Claude suggested changes included

## Technical Details

- crop_mirror_normalize F32 on HOST does the multiply-add in two places:

AVX path – `compute_cmn_*_host uses _mm256_fmadd_ps` (one IEEE-754 FMA rounding).
Scalar tails / partial rows – used `(src * mul) + off`, which is two roundings unless the compiler rewrites it to FMA.

- `__device__` helper was added so packed `float4` lanes use `fmaf` (IEEE-style fused multiply-add), matching the HOST path’s `std::fma` / AVX `fmadd` behavior instead of separate multiply and add.

## Test Plan

ctests for HIP and HOST imageTests

## Test Result

Should pass the crop_mirror_normalize failures on CI.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
