### PR TITLE
Bug fix for sobel filter - HIP 

### DIFF
--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -636,7 +636,11 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
             return RPP_ERROR_NOT_IMPLEMENTED;
 
         if (tempPtr != nullptr)
+        {
+            // Sobel runs asynchronously on the same stream; wait before freeing the greyscale scratch buffer.
+            CHECK_RETURN_STATUS(hipStreamSynchronize(handle.GetStream()));
             CHECK_RETURN_STATUS(hipFree(tempPtr));
+        }
 
         return RPP_SUCCESS;
     }

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -566,8 +566,7 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         {
             size_t elementSize = (srcDescPtr->dataType == RpptDataType::F32) ? 4 : 
                                     (srcDescPtr->dataType == RpptDataType::F16) ? 2 : 1;
-            size_t dataSize = static_cast<size_t>(dstDescPtr->offsetInBytes) +
-                               static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
+            size_t dataSize = dstDescPtr->strides.nStride * dstDescPtr->n * elementSize;
             CHECK_RETURN_STATUS(hipMalloc(&tempPtr, dataSize));
 
             RpptSubpixelLayout srcSubpixelLayout = RpptSubpixelLayout::RGBtype;

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -566,7 +566,9 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         {
             size_t elementSize = (srcDescPtr->dataType == RpptDataType::F32) ? 4 : 
                                     (srcDescPtr->dataType == RpptDataType::F16) ? 2 : 1;
-            size_t dataSize = dstDescPtr->strides.nStride * dstDescPtr->n * elementSize;
+            // rppt_color_to_greyscale above writes to (uint8_t*)tempPtr + dstDescPtr->offsetInBytes; allocation must cover that prefix.
+            size_t dataSize = static_cast<size_t>(dstDescPtr->offsetInBytes) +
+                               static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
 
             CHECK_RETURN_STATUS(hipMalloc(&tempPtr, dataSize));
 

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -566,7 +566,8 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         {
             size_t elementSize = (srcDescPtr->dataType == RpptDataType::F32) ? 4 : 
                                     (srcDescPtr->dataType == RpptDataType::F16) ? 2 : 1;
-            size_t dataSize = static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
+            size_t dataSize = static_cast<size_t>(dstDescPtr->offsetInBytes) +
+                               static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
             CHECK_RETURN_STATUS(hipMalloc(&tempPtr, dataSize));
 
             RpptSubpixelLayout srcSubpixelLayout = RpptSubpixelLayout::RGBtype;

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -566,10 +566,7 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         {
             size_t elementSize = (srcDescPtr->dataType == RpptDataType::F32) ? 4 : 
                                     (srcDescPtr->dataType == RpptDataType::F16) ? 2 : 1;
-            // rppt_color_to_greyscale above writes to (uint8_t*)tempPtr + dstDescPtr->offsetInBytes; allocation must cover that prefix.
-            size_t dataSize = static_cast<size_t>(dstDescPtr->offsetInBytes) +
-                               static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
-
+            size_t dataSize = static_cast<size_t>(dstDescPtr->strides.nStride) * static_cast<size_t>(dstDescPtr->n) * elementSize;
             CHECK_RETURN_STATUS(hipMalloc(&tempPtr, dataSize));
 
             RpptSubpixelLayout srcSubpixelLayout = RpptSubpixelLayout::RGBtype;


### PR DESCRIPTION
## Motivation

Creating this PR to check if it works to fix the failures on sobel filter for HIP backend, since I cannot reproduce on Navi31 or MI325 system locally. Claude suggested changes included

## Technical Details

With RGB→grey on HIP we hipMalloc scratch but may not allocate space for dstDescPtr->offsetInBytes while rppt_color_to_greyscale writes to tempPtr + offsetInBytes — causing OOB reads/writes and batch-dependent failures.

The Sobel RGB→grey path allocates a temporary buffer, then calls `rppt_color_to_greyscale`, which writes starting at `tempPtr + dstDescPtr->offsetInBytes`. The old size was only `nStride * n * elementSize`, so when `offsetInBytes > 0` the allocation could be too small and corrupt memory in a batch-dependent way.

## Test Plan
ctests for HIP and HOST image paths

## Test Result

Should pass the sobel filter on HIP backend and no regressions

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
