### PR TITLE
[Ctest] - Add tests to Ctests

### DIFF
--- a/utilities/test_suite/CMakeLists.txt
+++ b/utilities/test_suite/CMakeLists.txt
@@ -180,6 +180,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                             COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runImageTests.py --qa_mode 1 --batch_size 3
                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                         )
+                        # qa_mode 0 runs the full BitDepthTestMode matrix in runImageTests.py; qa_mode 1 only U8 and F32 for golden QA.
+                        add_test(
+                            NAME rpp_qa_tests_tensor_image_host_qa_mode_0
+                            COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runImageTests.py --qa_mode 0 --batch_size 3
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                        )
                     else()
                         message("-- ${Yellow}Warning: Skipping RPP-ctest 'HOST test set 1 - rpp_qa_tests_tensor_image_host_all' since OpenCV is not found!${ColourReset}")
                     endif(OpenCV_FOUND)
@@ -193,6 +199,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                         add_test(
                             NAME rpp_qa_tests_tensor_voxel_host_all
                             COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runVoxelTests.py --qa_mode 1 --batch_size 3
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                        )
+                        # qa_mode 0 runs U8 and F32 voxel unit tests; qa_mode 1 runs F32-only for golden QA.
+                        add_test(
+                            NAME rpp_qa_tests_tensor_voxel_host_qa_mode_0
+                            COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runVoxelTests.py --qa_mode 0 --batch_size 3
                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                         )
                     else()
@@ -223,6 +235,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                     COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runMiscTests.py --qa_mode 1 --batch_size 3
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 )
+                # runMiscTests.py uses a different bit-depth matrix for test_type 1 (performance) than for test_type 0 (unit); only misc needs both.
+                add_test(
+                    NAME rpp_qa_tests_tensor_misc_host_test_type_1
+                    COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runMiscTests.py --test_type 1 --batch_size 3
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                )
 
                 if( "${BACKEND}" STREQUAL "HIP")
                     if(NOT DEFINED HIP_PATH)
@@ -244,6 +262,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                                     COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runImageTests.py --qa_mode 1 --batch_size 3
                                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                                 )
+                                # qa_mode 0 runs the full BitDepthTestMode matrix in runImageTests.py; qa_mode 1 only U8 and F32 for golden QA.
+                                add_test(
+                                    NAME rpp_qa_tests_tensor_image_hip_qa_mode_0
+                                    COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runImageTests.py --qa_mode 0 --batch_size 3
+                                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                                )
                             else()
                                 message("-- ${Yellow}Warning: Skipping RPP-ctest 'HIP test set 1 - rpp_qa_tests_tensor_image_hip_all' since OpenCV is not found!${ColourReset}")
                             endif(OpenCV_FOUND)
@@ -257,6 +281,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                                 add_test(
                                     NAME rpp_qa_tests_tensor_voxel_hip_all
                                     COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runVoxelTests.py --qa_mode 1 --batch_size 3
+                                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                                )
+                                # qa_mode 0 runs U8 and F32 voxel unit tests; qa_mode 1 runs F32-only for golden QA.
+                                add_test(
+                                    NAME rpp_qa_tests_tensor_voxel_hip_qa_mode_0
+                                    COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runVoxelTests.py --qa_mode 0 --batch_size 3
                                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                                 )
                             else()
@@ -285,6 +315,12 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                         add_test(
                             NAME rpp_qa_tests_tensor_misc_hip_all
                             COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runMiscTests.py --qa_mode 1 --batch_size 3
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                        )
+                        # runMiscTests.py uses a different bit-depth matrix for test_type 1 (performance) than for test_type 0 (unit); only misc needs both.
+                        add_test(
+                            NAME rpp_qa_tests_tensor_misc_hip_test_type_1
+                            COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runMiscTests.py --test_type 1 --batch_size 3
                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                         )
 

--- a/utilities/test_suite/CMakeLists.txt
+++ b/utilities/test_suite/CMakeLists.txt
@@ -64,7 +64,7 @@ include(CTest)
 
 # Per-test CTest TIMEOUT (seconds) for selected long-running suites; all other tests use DartConfiguration.tcl TimeOut.
 # Increased timeout for: rpp_qa_tests_tensor_image_host_qa_mode_0, rpp_qa_tests_tensor_misc_host_test_type_1, rpp_qa_tests_tensor_image_hip_qa_mode_0
-set(RPP_CTEST_LONG_TEST_TIMEOUT_SEC 2000 CACHE STRING "CTest TIMEOUT override in seconds for long RPP tests (see set_tests_properties below).")
+set(RPP_CTEST_LONG_TEST_TIMEOUT_SEC 3000 CACHE STRING "CTest TIMEOUT override in seconds for long RPP tests (see set_tests_properties below).")
 
 #[[
 List of high level dependency checks - for RPP QA tests in utilities/test_suite/CMakeLists.txt are below.

--- a/utilities/test_suite/CMakeLists.txt
+++ b/utilities/test_suite/CMakeLists.txt
@@ -64,7 +64,7 @@ include(CTest)
 
 # Per-test CTest TIMEOUT (seconds) for selected long-running suites; all other tests use DartConfiguration.tcl TimeOut.
 # Increased timeout for: rpp_qa_tests_tensor_image_host_qa_mode_0, rpp_qa_tests_tensor_misc_host_test_type_1, rpp_qa_tests_tensor_image_hip_qa_mode_0
-set(RPP_CTEST_LONG_TEST_TIMEOUT_SEC 3000 CACHE STRING "CTest TIMEOUT override in seconds for long RPP tests (see set_tests_properties below).")
+set(RPP_CTEST_LONG_TEST_TIMEOUT_SEC 4000 CACHE STRING "CTest TIMEOUT override in seconds for long RPP tests (see set_tests_properties below).")
 
 #[[
 List of high level dependency checks - for RPP QA tests in utilities/test_suite/CMakeLists.txt are below.

--- a/utilities/test_suite/CMakeLists.txt
+++ b/utilities/test_suite/CMakeLists.txt
@@ -62,6 +62,10 @@ project(rpp-test)
 enable_testing()
 include(CTest)
 
+# Per-test CTest TIMEOUT (seconds) for selected long-running suites; all other tests use DartConfiguration.tcl TimeOut.
+# Increased timeout for: rpp_qa_tests_tensor_image_host_qa_mode_0, rpp_qa_tests_tensor_misc_host_test_type_1, rpp_qa_tests_tensor_image_hip_qa_mode_0
+set(RPP_CTEST_LONG_TEST_TIMEOUT_SEC 2000 CACHE STRING "CTest TIMEOUT override in seconds for long RPP tests (see set_tests_properties below).")
+
 #[[
 List of high level dependency checks - for RPP QA tests in utilities/test_suite/CMakeLists.txt are below.
 (The utilities/test_suite/HOST and utilities/test_suite/HIP folders are also designed to be built separately, so list of checks for those are present in the files "utilities/test_suite/HOST/CMakeLists.txt" and "utilities/test_suite/HIP/CMakeLists.txt")
@@ -186,6 +190,7 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                             COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runImageTests.py --qa_mode 0 --batch_size 3
                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                         )
+                        set_tests_properties(rpp_qa_tests_tensor_image_host_qa_mode_0 PROPERTIES TIMEOUT ${RPP_CTEST_LONG_TEST_TIMEOUT_SEC})
                     else()
                         message("-- ${Yellow}Warning: Skipping RPP-ctest 'HOST test set 1 - rpp_qa_tests_tensor_image_host_all' since OpenCV is not found!${ColourReset}")
                     endif(OpenCV_FOUND)
@@ -241,6 +246,7 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                     COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HOST/runMiscTests.py --test_type 1 --batch_size 3
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 )
+                set_tests_properties(rpp_qa_tests_tensor_misc_host_test_type_1 PROPERTIES TIMEOUT ${RPP_CTEST_LONG_TEST_TIMEOUT_SEC})
 
                 if( "${BACKEND}" STREQUAL "HIP")
                     if(NOT DEFINED HIP_PATH)
@@ -268,6 +274,7 @@ if(rpp_FOUND OR BUILD_FROM_SOURCE)
                                     COMMAND ${Python3_EXECUTABLE} ${RPP_TEST_SCRIPT_DIR}/HIP/runImageTests.py --qa_mode 0 --batch_size 3
                                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                                 )
+                                set_tests_properties(rpp_qa_tests_tensor_image_hip_qa_mode_0 PROPERTIES TIMEOUT ${RPP_CTEST_LONG_TEST_TIMEOUT_SEC})
                             else()
                                 message("-- ${Yellow}Warning: Skipping RPP-ctest 'HIP test set 1 - rpp_qa_tests_tensor_image_hip_all' since OpenCV is not found!${ColourReset}")
                             endif(OpenCV_FOUND)


### PR DESCRIPTION
## Motivation

Adding more tests to ctests to get more code coverage within ctests. Currently part of Jenkins, which needs to be removed.

## Technical Details

Add qa_mode 0 and test_type 1 for Image/Voxel/Misc and Audio so all cases are covered within ctests itself.

## Test Plan

Run ctests

## Test Result

All ctests must pass and code coverage should NOT drop 

Currently has 6 tests, will become 12:

```
(rock_0408) lakshmi@kapu:~/work/lk/rpp/build$ make test ARGS="-N"
Running tests...
Test project /home/lakshmi/work/lk/rpp/build
  Test  #1: rpp_qa_tests_tensor_image_host_all
  Test  #2: rpp_qa_tests_tensor_image_host_qa_mode_0
  Test  #3: rpp_qa_tests_tensor_voxel_host_all
  Test  #4: rpp_qa_tests_tensor_voxel_host_qa_mode_0
  Test  #5: rpp_qa_tests_tensor_misc_host_all
  Test  #6: rpp_qa_tests_tensor_misc_host_test_type_1
  Test  #7: rpp_qa_tests_tensor_image_hip_all
  Test  #8: rpp_qa_tests_tensor_image_hip_qa_mode_0
  Test  #9: rpp_qa_tests_tensor_voxel_hip_all
  Test #10: rpp_qa_tests_tensor_voxel_hip_qa_mode_0
  Test #11: rpp_qa_tests_tensor_misc_hip_all
  Test #12: rpp_qa_tests_tensor_misc_hip_test_type_1

Total Tests: 12
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
