### PR TITLE
[Bugfix] Fix use after free, synchronization issues, and incorrect RppStatus propagation in Sobel filter

### DIFF
--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -506,56 +506,54 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
 
         if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
         {
-            sobel_filter_host_tensor(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes,
-                                     dstDescPtr,
-                                     static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
-                                     dstDescPtr,
-                                     sobelType,
-                                     kernelSize,
-                                     roiTensorPtrSrc,
-                                     roiType,
-                                     handle);
+            return sobel_filter_host_tensor(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes,
+                                            dstDescPtr,
+                                            static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                            dstDescPtr,
+                                            sobelType,
+                                            kernelSize,
+                                            roiTensorPtrSrc,
+                                            roiType,
+                                            handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
         {
-            sobel_filter_host_tensor(reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
-                                     dstDescPtr,
-                                     reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-                                     dstDescPtr,
-                                     sobelType,
-                                     kernelSize,
-                                     roiTensorPtrSrc,
-                                     roiType,
-                                     handle);
+            return sobel_filter_host_tensor(reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
+                                            dstDescPtr,
+                                            reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                            dstDescPtr,
+                                            sobelType,
+                                            kernelSize,
+                                            roiTensorPtrSrc,
+                                            roiType,
+                                            handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
         {
-            sobel_filter_host_tensor(reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
-                                     dstDescPtr,
-                                     reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-                                     dstDescPtr,
-                                     sobelType,
-                                     kernelSize,
-                                     roiTensorPtrSrc,
-                                     roiType,
-                                     handle);
+            return sobel_filter_host_tensor(reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
+                                            dstDescPtr,
+                                            reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                            dstDescPtr,
+                                            sobelType,
+                                            kernelSize,
+                                            roiTensorPtrSrc,
+                                            roiType,
+                                            handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
         {
-            sobel_filter_host_tensor(static_cast<Rpp8s*>(tempPtr) + srcDescPtr->offsetInBytes,
-                                     dstDescPtr,
-                                     static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
-                                     dstDescPtr,
-                                     sobelType,
-                                     kernelSize,
-                                     roiTensorPtrSrc,
-                                     roiType,
-                                     handle);
+            return sobel_filter_host_tensor(static_cast<Rpp8s*>(tempPtr) + srcDescPtr->offsetInBytes,
+                                            dstDescPtr,
+                                            static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                            dstDescPtr,
+                                            sobelType,
+                                            kernelSize,
+                                            roiTensorPtrSrc,
+                                            roiType,
+                                            handle);
         }
         else
             return RPP_ERROR_NOT_IMPLEMENTED;
-
-        return RPP_SUCCESS;
     }
 #ifdef GPU_SUPPORT
     else if ((handleBackend == RppBackend::RPP_HIP_BACKEND) && (executionBackend == RppBackend::RPP_HIP_BACKEND))
@@ -580,67 +578,71 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
             inputDesc = dstDescPtr;
         }
         srcPtr = (tempPtr == nullptr) ? srcPtr : tempPtr;
-        RPP_HIP_RETURN_IF_ERROR(hipStreamSynchronize(handle.GetStream()));
 
+        RppStatus status = RPP_SUCCESS;
         if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
         {
-            hip_exec_sobel_filter_tensor(static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes,
-                                         inputDesc,
-                                         static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
-                                         dstDescPtr,
-                                         sobelType,
-                                         kernelSize,
-                                         roiTensorPtrSrc,
-                                         roiType,
-                                         handle);
+            status = hip_exec_sobel_filter_tensor(static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes,
+                                                  inputDesc,
+                                                  static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                                  dstDescPtr,
+                                                  sobelType,
+                                                  kernelSize,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
         {
-            hip_exec_sobel_filter_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes),
-                                         inputDesc,
-                                         (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-                                         dstDescPtr,
-                                         sobelType,
-                                         kernelSize,
-                                         roiTensorPtrSrc,
-                                         roiType,
-                                         handle);
+            status = hip_exec_sobel_filter_tensor((half*) (static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes),
+                                                  inputDesc,
+                                                  (half*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                                  dstDescPtr,
+                                                  sobelType,
+                                                  kernelSize,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
         {
-            hip_exec_sobel_filter_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes),
-                                         inputDesc,
-                                         (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
-                                         dstDescPtr,
-                                         sobelType,
-                                         kernelSize,
-                                         roiTensorPtrSrc,
-                                         roiType,
-                                         handle);
+            status = hip_exec_sobel_filter_tensor((Rpp32f*) (static_cast<Rpp8u*>(srcPtr) + inputDesc->offsetInBytes),
+                                                  inputDesc,
+                                                  (Rpp32f*) (static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
+                                                  dstDescPtr,
+                                                  sobelType,
+                                                  kernelSize,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  handle);
         }
         else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
         {
-            hip_exec_sobel_filter_tensor(static_cast<Rpp8s*>(srcPtr) + inputDesc->offsetInBytes,
-                                         inputDesc,
-                                         static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
-                                         dstDescPtr,
-                                         sobelType,
-                                         kernelSize,
-                                         roiTensorPtrSrc,
-                                         roiType,
-                                         handle);
+            status = hip_exec_sobel_filter_tensor(static_cast<Rpp8s*>(srcPtr) + inputDesc->offsetInBytes,
+                                                  inputDesc,
+                                                  static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
+                                                  dstDescPtr,
+                                                  sobelType,
+                                                  kernelSize,
+                                                  roiTensorPtrSrc,
+                                                  roiType,
+                                                  handle);
         }
         else
-            return RPP_ERROR_NOT_IMPLEMENTED;
+            status = RPP_ERROR_NOT_IMPLEMENTED;
 
         if (tempPtr != nullptr)
         {
             // Sobel runs asynchronously on the same stream; wait before freeing the greyscale scratch buffer.
-            RPP_HIP_RETURN_IF_ERROR(hipStreamSynchronize(handle.GetStream()));
-            RPP_HIP_RETURN_IF_ERROR(hipFree(tempPtr));
+            hipError_t syncErr = hipStreamSynchronize(handle.GetStream());
+            hipError_t freeErr = hipFree(tempPtr);
+            if (status == RPP_SUCCESS && (syncErr != hipSuccess || freeErr != hipSuccess))
+            {
+                return RPP_ERROR_HIP_RUNTIME;
+            }
         }
 
-        return RPP_SUCCESS;
+        return status;
     }
 #endif
 

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -495,6 +495,7 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
     {
         // convert image to grey scale if input is RGB image
         RppPtr_t tempPtr = srcPtr;
+        RpptDescPtr inputDesc = srcDescPtr;
         if (srcDescPtr->c == 3)
         {
             RpptSubpixelLayout srcSubpixelLayout = RpptSubpixelLayout::RGBtype;
@@ -502,12 +503,14 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
             RppStatus errorStatus = rppt_color_to_greyscale(srcPtr, srcDescPtr, tempPtr, dstDescPtr, srcSubpixelLayout, rppHandle, RppBackend::RPP_HOST_BACKEND);
             if(errorStatus != RPP_SUCCESS)
                 return errorStatus;
+            // Greyscale wrote to tempPtr using dstDescPtr's layout/offset; sobel must read with the same descriptor.
+            inputDesc = dstDescPtr;
         }
 
         if ((srcDescPtr->dataType == RpptDataType::U8) && (dstDescPtr->dataType == RpptDataType::U8))
         {
-            return sobel_filter_host_tensor(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes,
-                                            dstDescPtr,
+            return sobel_filter_host_tensor(static_cast<Rpp8u*>(tempPtr) + inputDesc->offsetInBytes,
+                                            inputDesc,
                                             static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes,
                                             dstDescPtr,
                                             sobelType,
@@ -518,8 +521,8 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         }
         else if ((srcDescPtr->dataType == RpptDataType::F16) && (dstDescPtr->dataType == RpptDataType::F16))
         {
-            return sobel_filter_host_tensor(reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
-                                            dstDescPtr,
+            return sobel_filter_host_tensor(reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(tempPtr) + inputDesc->offsetInBytes),
+                                            inputDesc,
                                             reinterpret_cast<Rpp16f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
                                             dstDescPtr,
                                             sobelType,
@@ -530,8 +533,8 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         }
         else if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
         {
-            return sobel_filter_host_tensor(reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(tempPtr) + srcDescPtr->offsetInBytes),
-                                            dstDescPtr,
+            return sobel_filter_host_tensor(reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(tempPtr) + inputDesc->offsetInBytes),
+                                            inputDesc,
                                             reinterpret_cast<Rpp32f*>(static_cast<Rpp8u*>(dstPtr) + dstDescPtr->offsetInBytes),
                                             dstDescPtr,
                                             sobelType,
@@ -542,8 +545,8 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
         }
         else if ((srcDescPtr->dataType == RpptDataType::I8) && (dstDescPtr->dataType == RpptDataType::I8))
         {
-            return sobel_filter_host_tensor(static_cast<Rpp8s*>(tempPtr) + srcDescPtr->offsetInBytes,
-                                            dstDescPtr,
+            return sobel_filter_host_tensor(static_cast<Rpp8s*>(tempPtr) + inputDesc->offsetInBytes,
+                                            inputDesc,
                                             static_cast<Rpp8s*>(dstPtr) + dstDescPtr->offsetInBytes,
                                             dstDescPtr,
                                             sobelType,

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -565,14 +565,13 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
             size_t elementSize = (srcDescPtr->dataType == RpptDataType::F32) ? 4 : 
                                     (srcDescPtr->dataType == RpptDataType::F16) ? 2 : 1;
             size_t dataSize = dstDescPtr->strides.nStride * dstDescPtr->n * elementSize;
-            RPP_HIP_RETURN_IF_ERROR(hipMalloc(&tempPtr, dataSize));
+            RPP_HIP_RETURN_IF_ERROR(hipMallocAsync(&tempPtr, dataSize, handle.GetStream()));
 
             RpptSubpixelLayout srcSubpixelLayout = RpptSubpixelLayout::RGBtype;
-            RppStatus errorStatus = rppt_color_to_greyscale(srcPtr, srcDescPtr, tempPtr, dstDescPtr, srcSubpixelLayout, rppHandle, RppBackend::RPP_HIP_BACKEND);        
+            RppStatus errorStatus = rppt_color_to_greyscale(srcPtr, srcDescPtr, tempPtr, dstDescPtr, srcSubpixelLayout, rppHandle, RppBackend::RPP_HIP_BACKEND);
             if(errorStatus != RPP_SUCCESS)
             {
-                // Ignore the error status of hipFree to preserve the root cause of the error
-                (void)hipFree(tempPtr);
+                (void)hipFreeAsync(tempPtr, handle.GetStream());
                 return errorStatus;
             }
             inputDesc = dstDescPtr;
@@ -633,13 +632,9 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
 
         if (tempPtr != nullptr)
         {
-            // Sobel runs asynchronously on the same stream; wait before freeing the greyscale scratch buffer.
-            hipError_t syncErr = hipStreamSynchronize(handle.GetStream());
-            hipError_t freeErr = hipFree(tempPtr);
-            if (status == RPP_SUCCESS && (syncErr != hipSuccess || freeErr != hipSuccess))
-            {
+            hipError_t freeErr = hipFreeAsync(tempPtr, handle.GetStream());
+            if (status == RPP_SUCCESS && freeErr != hipSuccess)
                 return RPP_ERROR_HIP_RUNTIME;
-            }
         }
 
         return status;

--- a/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
+++ b/src/modules/tensor/rppt_tensor_filter_augmentations.cpp
@@ -571,6 +571,7 @@ RppStatus rppt_sobel_filter(RppPtr_t srcPtr,
             RppStatus errorStatus = rppt_color_to_greyscale(srcPtr, srcDescPtr, tempPtr, dstDescPtr, srcSubpixelLayout, rppHandle, RppBackend::RPP_HIP_BACKEND);
             if(errorStatus != RPP_SUCCESS)
             {
+                // Ignore hipFree status to preserve the root cause of the error
                 (void)hipFreeAsync(tempPtr, handle.GetStream());
                 return errorStatus;
             }


### PR DESCRIPTION
## Technical Details
- Resolves #687 
- Use asynchronous versions for HIP runtime calls to honor stream semantics.
- Ensure return value for `sobel_filter` host/hip` kernels is checked and propagated by dispatcher.
- Ensure `tempPtr` is always cleaned up even when an error may cause an early return.